### PR TITLE
fix(clang-tidy): unblock nightly CI + document v22 tech debt

### DIFF
--- a/docs/CODE_QUALITY.md
+++ b/docs/CODE_QUALITY.md
@@ -667,6 +667,38 @@ release April 23, 2026), the following CI/tooling simplifications become possibl
 3. **`.clang-tidy` / `conanfile.py`** — No changes needed; C++23 settings
    remain correct.
 
+### Tech debt: newer clang-tidy versions surface ~1,400 extra findings
+
+CI pins clang-tidy-19 (Ubuntu 24.04 default). Running `./scripts/tidy.sh check`
+on a host with a newer clang-tidy (e.g., LLVM 21 on the upcoming Ubuntu 26.04
+runner, or LLVM 22 on a developer machine) surfaces **~1,400 additional
+warnings** from checks that didn't exist in v19. None of these block CI today,
+but they will the moment the runner is upgraded, so a decision is needed per
+check: **fix in code** or **suppress in `.clang-tidy`**.
+
+Snapshot from a clang-tidy 22 run on `main` (2026-05-17). Counts are raw
+per-emission; clang-tidy deduplicates headers reported across multiple
+translation units down to ~1,400 unique issues.
+
+| Check | Count | Recommended disposition |
+| --- | ---: | --- |
+| `cppcoreguidelines-pro-bounds-avoid-unchecked-container-access` | 4305 | **Suppress.** Flags every `vec[i]`/`arr[i]` access; replacing with `.at()` adds exception-throw branches everywhere a fixed-size 9×9 board is indexed by a known-valid coordinate. Cost is real (perf + churn), value is low for a Sudoku domain where indices are derived from `Position{row,col}` already constrained to 0–8. |
+| `modernize-avoid-c-style-cast` | 6 | **Fix in code.** Small count, mechanical conversion to `static_cast` / `reinterpret_cast`. |
+| `modernize-use-designated-initializers` | 5 | **Fix in code.** Aligns with the project's existing C++20 designated-initializer style. |
+| `readability-math-missing-parentheses` | 2 | **Fix in code.** Trivial. |
+
+**Already resolved on `bugfix/clang-tidy-warnings` (2026-05-17):**
+
+- `bugprone-random-generator-seed` (1 emission, `solution_counter.cpp:338`) — false positive; the fixed Zobrist seed is required for hash stability across runs. Already NOLINT'd for `cert-msc32-c,cert-msc51-cpp` (the v18-era names of the same check); extended the existing NOLINTNEXTLINE to cover the new check name.
+- `bugprone-exception-escape` (1 emission, `main.cpp:141`) — false positive; clang-tidy didn't track the `has_value()` guard preceding `result.value()`. Replaced `result.value()` with `*result` (non-throwing dereference, canonical idiom after a guard).
+
+**Recommended sequencing for the remaining work:** address the small-count
+checks in code (single small commit each), then add
+`-cppcoreguidelines-pro-bounds-avoid-unchecked-container-access` to the disable
+list in `.clang-tidy` with a comment explaining the rationale. Do this
+**before** the Ubuntu 26.04 migration step above lands, so the runner upgrade
+doesn't turn 4,300 warnings into a CI breakage.
+
 ---
 
 ## AddressSanitizer + UBSan

--- a/src/core/i_puzzle_generator.h
+++ b/src/core/i_puzzle_generator.h
@@ -17,9 +17,11 @@
 #pragma once
 
 #include "core/board_data.h"
+#include "core/constants.h"
 #include "cpu_features.h"
 #include "solving_technique.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <optional>
@@ -38,6 +40,11 @@ enum class Difficulty : std::uint8_t {
     Expert = 3,  // 17-27 clues (rating determines difficulty)
     Master = 4   // 17-27 clues (open-ended, hardest puzzles)
 };
+
+// Keep DIFFICULTY_COUNT in lockstep with the enum. If a level is added or removed,
+// bump DIFFICULTY_COUNT in core/constants.h or this assertion fires at compile time.
+static_assert(static_cast<std::size_t>(Difficulty::Master) + 1 == DIFFICULTY_COUNT,
+              "DIFFICULTY_COUNT must match the number of Difficulty enum values");
 
 /// Puzzle generation settings
 struct GenerationSettings {

--- a/src/core/i_statistics_manager.h
+++ b/src/core/i_statistics_manager.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "core/constants.h"
 #include "i_puzzle_generator.h"
 
 #include <array>
@@ -45,21 +46,21 @@ struct GameStats {
 /// Aggregate statistics across multiple games
 struct AggregateStats {
     // Per difficulty level
-    std::array<int, 5> games_played{0, 0, 0, 0, 0};  // Easy, Medium, Hard, Expert, Master
-    std::array<int, 5> games_completed{0, 0, 0, 0, 0};
-    std::array<std::chrono::milliseconds, 5> best_times{
+    std::array<int, DIFFICULTY_COUNT> games_played{0, 0, 0, 0, 0};  // Easy, Medium, Hard, Expert, Master
+    std::array<int, DIFFICULTY_COUNT> games_completed{0, 0, 0, 0, 0};
+    std::array<std::chrono::milliseconds, DIFFICULTY_COUNT> best_times{
         std::chrono::milliseconds::max(), std::chrono::milliseconds::max(), std::chrono::milliseconds::max(),
         std::chrono::milliseconds::max(), std::chrono::milliseconds::max()};
-    std::array<std::chrono::milliseconds, 5> average_times{std::chrono::milliseconds{0}, std::chrono::milliseconds{0},
-                                                           std::chrono::milliseconds{0}, std::chrono::milliseconds{0},
-                                                           std::chrono::milliseconds{0}};
+    std::array<std::chrono::milliseconds, DIFFICULTY_COUNT> average_times{
+        std::chrono::milliseconds{0}, std::chrono::milliseconds{0}, std::chrono::milliseconds{0},
+        std::chrono::milliseconds{0}, std::chrono::milliseconds{0}};
 
     // Rating statistics per difficulty (SE scale)
-    std::array<double, 5> average_ratings{0.0, 0.0, 0.0, 0.0, 0.0};
-    std::array<double, 5> min_ratings{std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
-                                      std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
-                                      std::numeric_limits<double>::max()};
-    std::array<double, 5> max_ratings{0.0, 0.0, 0.0, 0.0, 0.0};
+    std::array<double, DIFFICULTY_COUNT> average_ratings{0.0, 0.0, 0.0, 0.0, 0.0};
+    std::array<double, DIFFICULTY_COUNT> min_ratings{
+        std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
+        std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
+    std::array<double, DIFFICULTY_COUNT> max_ratings{0.0, 0.0, 0.0, 0.0, 0.0};
 
     // Overall stats
     int total_games{0};
@@ -144,11 +145,11 @@ public:
 
     /// Gets personal best times for each difficulty
     /// @return Array of best times [Easy, Medium, Hard, Expert, Master]
-    [[nodiscard]] virtual std::array<std::chrono::milliseconds, 5> getBestTimes() const = 0;
+    [[nodiscard]] virtual std::array<std::chrono::milliseconds, DIFFICULTY_COUNT> getBestTimes() const = 0;
 
     /// Calculates completion percentage for each difficulty
     /// @return Array of completion percentages [Easy, Medium, Hard, Expert, Master]
-    [[nodiscard]] virtual std::array<double, 5> getCompletionRates() const = 0;
+    [[nodiscard]] virtual std::array<double, DIFFICULTY_COUNT> getCompletionRates() const = 0;
 
     /// Exports statistics to a file
     /// @param file_path Path to export file

--- a/src/core/puzzle_analyzer.cpp
+++ b/src/core/puzzle_analyzer.cpp
@@ -167,7 +167,7 @@ std::expected<DifficultyScore, ScoringError> PuzzleAnalyzer::scoreDifficulty(con
     for (const auto& step : result->solve_path) {
         score.max_rating = std::max(score.max_rating, step.rating);
         const int id = static_cast<int>(step.technique);
-        if (std::find(score.technique_ids.begin(), score.technique_ids.end(), id) == score.technique_ids.end()) {
+        if (std::ranges::find(score.technique_ids, id) == score.technique_ids.end()) {
             score.technique_ids.push_back(id);
         }
     }

--- a/src/core/puzzle_analyzer.h
+++ b/src/core/puzzle_analyzer.h
@@ -57,7 +57,7 @@ struct ParseErrorDetail {
 /// Carries the offending cells so the View can highlight them (pre-mortem #5).
 /// Empty `conflicting_cells` is a sentinel meaning "no specific cells" (not currently emitted).
 struct BoardValidationError {
-    std::vector<Position> conflicting_cells{};
+    std::vector<Position> conflicting_cells;
 
     bool operator==(const BoardValidationError&) const = default;
 };
@@ -84,7 +84,7 @@ enum class UniquenessResult : std::uint8_t {
 struct DifficultyScore {
     double max_rating{0.0};
     bool requires_backtracking{false};
-    std::vector<int> technique_ids{};
+    std::vector<int> technique_ids;
 
     bool operator==(const DifficultyScore&) const = default;
 };

--- a/src/core/solution_counter.cpp
+++ b/src/core/solution_counter.cpp
@@ -334,7 +334,7 @@ void SolutionCounter::countSolutionsHelper(Board& board, ConstraintState& state,
 
 void SolutionCounter::initializeZobristTable() {
     // Use fixed seed for Zobrist table (must be consistent across runs)
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) - Deterministic seed required for Zobrist hashing
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed) - Deterministic seed required for Zobrist hashing
     std::mt19937_64 rng(0x123456789ABCDEF0ULL);
     std::uniform_int_distribution<uint64_t> dist(0, UINT64_MAX);
 

--- a/src/core/statistics_manager.cpp
+++ b/src/core/statistics_manager.cpp
@@ -286,7 +286,7 @@ std::expected<std::vector<GameStats>, StatisticsError> StatisticsManager::getRec
     return all;
 }
 
-std::array<std::chrono::milliseconds, 5> StatisticsManager::getBestTimes() const {
+std::array<std::chrono::milliseconds, DIFFICULTY_COUNT> StatisticsManager::getBestTimes() const {
     auto stats_result = getAggregateStats();
     if (!stats_result) {
         return {};  // Return empty array on error
@@ -295,14 +295,14 @@ std::array<std::chrono::milliseconds, 5> StatisticsManager::getBestTimes() const
     return stats_result->best_times;
 }
 
-std::array<double, 5> StatisticsManager::getCompletionRates() const {
+std::array<double, DIFFICULTY_COUNT> StatisticsManager::getCompletionRates() const {
     auto stats_result = getAggregateStats();
     if (!stats_result) {
         return {};  // Return empty array on error
     }
 
     const auto& stats = *stats_result;
-    std::array<double, 5> rates{};
+    std::array<double, DIFFICULTY_COUNT> rates{};
 
     for (size_t i = 0; i < DIFFICULTY_COUNT; ++i) {
         if (stats.games_played[i] > 0) {

--- a/src/core/statistics_manager.h
+++ b/src/core/statistics_manager.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "core/constants.h"
 #include "core/i_puzzle_generator.h"
 #include "encryption_manager.h"
 #include "i_statistics_manager.h"
@@ -64,8 +65,8 @@ public:
     [[nodiscard]] std::expected<std::vector<GameStats>, StatisticsError> getAllSessions() const override;
     [[nodiscard]] std::expected<std::vector<GameStats>, StatisticsError> getRecentGames(int count) const override;
 
-    std::array<std::chrono::milliseconds, 5> getBestTimes() const override;
-    std::array<double, 5> getCompletionRates() const override;
+    std::array<std::chrono::milliseconds, DIFFICULTY_COUNT> getBestTimes() const override;
+    std::array<double, DIFFICULTY_COUNT> getCompletionRates() const override;
 
     // Import/Export
     std::expected<void, StatisticsError> exportStats(const std::string& file_path) const override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) {
                 spdlog::info("Auto-save contains completed game, starting fresh");
                 view_model->startNewGame(default_difficulty);
             } else {
-                view_model->restoreGameState(result.value());
+                view_model->restoreGameState(*result);
             }
         } else {
             spdlog::warn("Auto-save load failed: {}, starting new game", static_cast<int>(result.error()));

--- a/src/view/main_window.cpp
+++ b/src/view/main_window.cpp
@@ -272,6 +272,12 @@ void MainWindow::setupCentralWidget() {
 }
 
 void MainWindow::setupMenuBar() {
+    setupGameMenu();
+    setupEditMenu();
+    setupHelpMenu();
+}
+
+void MainWindow::setupGameMenu() {
     auto* game_menu = menuBar()->addMenu(QString("&%1").arg(qstr(core::loc("Sudoku", "Game"))));
 
     game_menu->addAction(QString("&%1").arg(qstr(core::loc("Sudoku", "New Game"))), QKeySequence("Ctrl+N"), this,
@@ -348,7 +354,9 @@ void MainWindow::setupMenuBar() {
     game_menu->addSeparator();
     game_menu->addAction(QString("&%1").arg(qstr(core::loc("Sudoku", "Exit"))), QKeySequence("Alt+F4"), this,
                          &QWidget::close);
+}
 
+void MainWindow::setupEditMenu() {
     auto* edit_menu = menuBar()->addMenu(QString("&%1").arg(qstr(core::loc("Sudoku", "Edit"))));
     edit_menu->addAction(QString("&%1").arg(qstr(core::loc("Sudoku", "Undo"))), QKeySequence("Ctrl+Z"), this, [this]() {
         if (view_model_) {
@@ -380,7 +388,9 @@ void MainWindow::setupMenuBar() {
                                  view_model_->clearCell(pos.value());
                              }
                          });
+}
 
+void MainWindow::setupHelpMenu() {
     auto* help_menu = menuBar()->addMenu(QString("&%1").arg(qstr(core::loc("Sudoku", "Help"))));
     help_menu->addAction(qstr(core::loc("Sudoku", "Get Hint")), QKeySequence("H"), this, [this]() {
         if (view_model_ && view_model_->getHintCount() > 0) {

--- a/src/view/main_window.h
+++ b/src/view/main_window.h
@@ -147,6 +147,9 @@ private:
 
     // Setup methods
     void setupMenuBar();
+    void setupGameMenu();
+    void setupEditMenu();
+    void setupHelpMenu();
     void setupToolBar();
     void setupStatusBar();
     void setupCentralWidget();

--- a/src/view/puzzle_import_dialog.cpp
+++ b/src/view/puzzle_import_dialog.cpp
@@ -38,7 +38,9 @@ QString qstr(std::string_view sv) {
 
 }  // namespace
 
-PuzzleImportDialog::PuzzleImportDialog(QWidget* parent) : QDialog(parent) {
+PuzzleImportDialog::PuzzleImportDialog(QWidget* parent)
+    : QDialog(parent), text_edit_(new QTextEdit), import_btn_(new QPushButton(qstr(core::loc("Sudoku", "Import")))),
+      cancel_btn_(new QPushButton(qstr(core::loc("Sudoku", "Cancel")))), error_label_(new QLabel) {
     setWindowTitle(qstr(core::loc("Sudoku", "Import Custom Puzzle")));
     setModal(true);
     resize(420, 320);
@@ -51,7 +53,6 @@ PuzzleImportDialog::PuzzleImportDialog(QWidget* parent) : QDialog(parent) {
     prompt->setWordWrap(true);
     layout->addWidget(prompt);
 
-    text_edit_ = new QTextEdit;
     text_edit_->setAcceptRichText(false);
     text_edit_->setPlaceholderText(qstr(core::loc("Sudoku", "Paste puzzle here…")));
     // Cap document growth in-place so an oversized paste doesn't sit in memory until
@@ -70,7 +71,6 @@ PuzzleImportDialog::PuzzleImportDialog(QWidget* parent) : QDialog(parent) {
     });
     layout->addWidget(text_edit_, 1);
 
-    error_label_ = new QLabel;
     error_label_->setTextFormat(Qt::PlainText);
     error_label_->setStyleSheet(QString("QLabel { color: %1; }").arg(StyleColors::ERROR_COLOR));
     error_label_->setWordWrap(true);
@@ -79,8 +79,6 @@ PuzzleImportDialog::PuzzleImportDialog(QWidget* parent) : QDialog(parent) {
 
     auto* buttons = new QHBoxLayout;
     buttons->addStretch();
-    cancel_btn_ = new QPushButton(qstr(core::loc("Sudoku", "Cancel")));
-    import_btn_ = new QPushButton(qstr(core::loc("Sudoku", "Import")));
     import_btn_->setDefault(true);
     buttons->addWidget(cancel_btn_);
     buttons->addWidget(import_btn_);

--- a/src/view/puzzle_technique_dialog.cpp
+++ b/src/view/puzzle_technique_dialog.cpp
@@ -96,7 +96,9 @@ constexpr std::array kSelectableTechniques = {
 
 }  // namespace
 
-PuzzleTechniqueDialog::PuzzleTechniqueDialog(QWidget* parent) : QDialog(parent) {
+PuzzleTechniqueDialog::PuzzleTechniqueDialog(QWidget* parent)
+    : QDialog(parent), technique_combo_(new QComboBox), find_btn_(new QPushButton(qstr(core::loc("Sudoku", "Find")))),
+      cancel_btn_(new QPushButton(qstr(core::loc("Sudoku", "Cancel")))) {
     setWindowTitle(qstr(core::loc("Sudoku", "Find Step by Technique")));
     setModal(true);
     resize(360, 140);
@@ -107,7 +109,6 @@ PuzzleTechniqueDialog::PuzzleTechniqueDialog(QWidget* parent) : QDialog(parent) 
     prompt->setTextFormat(Qt::PlainText);
     layout->addWidget(prompt);
 
-    technique_combo_ = new QComboBox;
     for (auto t : kSelectableTechniques) {
         technique_combo_->addItem(qstr(core::getLocalizedTechniqueName(t)), static_cast<int>(t));
     }
@@ -115,8 +116,6 @@ PuzzleTechniqueDialog::PuzzleTechniqueDialog(QWidget* parent) : QDialog(parent) 
 
     auto* buttons = new QHBoxLayout;
     buttons->addStretch();
-    cancel_btn_ = new QPushButton(qstr(core::loc("Sudoku", "Cancel")));
-    find_btn_ = new QPushButton(qstr(core::loc("Sudoku", "Find")));
     find_btn_->setDefault(true);
     buttons->addWidget(cancel_btn_);
     buttons->addWidget(find_btn_);

--- a/src/view_model/game_view_model_state.cpp
+++ b/src/view_model/game_view_model_state.cpp
@@ -127,9 +127,10 @@ void GameViewModel::cycleInputMode() {
         case InputMode::Notes:
             next = InputMode::Color;
             break;
-        // EditGivens is an explicit-entry mode (enterEditMode/commitEditedPuzzle). The cycle
-        // button shouldn't bring users here or out of here; map back to Normal defensively in
-        // case the View triggers it anyway — same target as the Color case.
+        // Color and EditGivens deliberately share a body — both reset to Normal.
+        // EditGivens is an explicit-entry mode (enterEditMode/commitEditedPuzzle), so the
+        // cycle button shouldn't reach it; mapping to Normal is a defensive fallback in case
+        // the View triggers it anyway.
         case InputMode::Color:
         case InputMode::EditGivens:
             next = InputMode::Normal;

--- a/src/view_model/game_view_model_state.cpp
+++ b/src/view_model/game_view_model_state.cpp
@@ -127,13 +127,11 @@ void GameViewModel::cycleInputMode() {
         case InputMode::Notes:
             next = InputMode::Color;
             break;
+        // EditGivens is an explicit-entry mode (enterEditMode/commitEditedPuzzle). The cycle
+        // button shouldn't bring users here or out of here; map back to Normal defensively in
+        // case the View triggers it anyway — same target as the Color case.
         case InputMode::Color:
-            next = InputMode::Normal;
-            break;
         case InputMode::EditGivens:
-            // EditGivens is an explicit-entry mode (enterEditMode/commitEditedPuzzle).
-            // The cycle button shouldn't bring users here or out of here; map back to
-            // Normal defensively in case the View triggers it anyway.
             next = InputMode::Normal;
             break;
     }


### PR DESCRIPTION
## Summary

- Silences the six clang-tidy-19 errors that have been breaking the nightly job (latest failing run: [25981264616](https://github.com/darkstar79/sudoku-cpp/actions/runs/25981264616/job/76370316838)) — all style-level findings, no behavior change. Affected checks: `readability-redundant-member-init`, `cppcoreguidelines-prefer-member-initializer`, `readability-function-cognitive-complexity`/`function-size`, `modernize-use-ranges`, `bugprone-branch-clone`.
- Silences two `bugprone-*` findings that a newer clang-tidy (v20+) catches: `bugprone-random-generator-seed` on the Zobrist seed (extended an existing NOLINT; the constant seed is required for hash stability) and `bugprone-exception-escape` in `main()` (switched `result.value()` → `*result` after the existing `has_value()` guard — cleaner idiom, no NOLINT needed).
- Cleans up the loudest false signal the v22 magic-numbers check surfaced: `i_statistics_manager.h` hardcoded the integer `5` in seven `std::array<…, 5>` declarations while `core/constants.h` already exported `DIFFICULTY_COUNT`. Threaded the constant through and added a `static_assert` next to the `Difficulty` enum so future drift fails at compile time.
- Documents the broader v22 tech-debt picture (~1,400 additional findings on a clang-tidy ≥ 20 host, dominated by `cppcoreguidelines-pro-bounds-avoid-unchecked-container-access`) in `docs/CODE_QUALITY.md` with per-check disposition (suppress vs fix). Will need to be acted on before the Ubuntu 26.04 runner migration lands, otherwise the runner bump turns 4,300 emissions into a CI breakage.

No user-visible or packager-visible changes, so no CHANGELOG entry.

## Test plan

- [x] `cmake --build --preset release` clean
- [x] Unit tests pass (989 cases, 14,993 assertions)
- [x] Integration tests pass (14 cases, 271 assertions)
- [x] Local clang-tidy (v22) run on edited files: none of the v19 checks fire, the two `bugprone-*` findings are silenced
- [x] **Nightly clang-tidy job on this branch goes green** — this is the real verification; local can't run clang-tidy-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)