### PR TITLE
feat(i18n): dynamic locale discovery + BCP 47 validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ First tagged release (in preparation). Adds the custom-puzzle feature suite on t
 - **Solver gains budget-bearing overloads** — `solvePuzzle(board, std::chrono::milliseconds)` and a technique-targeted dispatch. The backtracking fallback now honors the deadline so adversarial inputs cannot hang the UI.
 - **Hint message clearing** — stale `hintMessage` is cleared on every `getHint` exit path so dismissed hints don't reappear after subsequent moves.
 - **Session lifecycle** — entering edit mode finalizes any active statistics session as abandoned (previously orphaned).
+- **Language selector** now discovers installed translations automatically. Packagers can ship a new locale by adding `sudoku_<code>.qm` to the translations directory and a matching `.ts` entry in `CMakeLists.txt`; no C++ change is required. Locale codes from `settings.yaml`, the legacy `language.txt`, and the Settings dialog are validated against a BCP 47 subset (`^[a-z]{2,3}(_[A-Z]{2})?$`) before being interpolated into a filesystem path.
 
 ### Removed
 

--- a/src/core/locale_utils.cpp
+++ b/src/core/locale_utils.cpp
@@ -104,8 +104,6 @@ std::vector<std::string> scanInstalledLocales(const std::filesystem::path& trans
     }
 
     std::ranges::sort(result);
-    const auto trim = std::ranges::unique(result);
-    result.erase(trim.begin(), trim.end());
     return result;
 }
 

--- a/src/core/locale_utils.cpp
+++ b/src/core/locale_utils.cpp
@@ -1,0 +1,112 @@
+// sudoku-cpp - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "locale_utils.h"
+
+#include <algorithm>
+#include <string_view>
+#include <system_error>
+
+namespace sudoku::core {
+
+namespace {
+
+constexpr std::string_view kFilenamePrefix = "sudoku_";
+constexpr std::string_view kFilenameSuffix = ".qm";
+
+[[nodiscard]] constexpr bool isLower(char c) noexcept {
+    return c >= 'a' && c <= 'z';
+}
+
+[[nodiscard]] constexpr bool isUpper(char c) noexcept {
+    return c >= 'A' && c <= 'Z';
+}
+
+}  // namespace
+
+bool isValidLocaleCode(std::string_view code) noexcept {
+    if (code.empty()) {
+        return false;
+    }
+
+    size_t i = 0;
+    while (i < code.size() && isLower(code[i])) {
+        ++i;
+    }
+    if (i < 2 || i > 3) {
+        return false;
+    }
+
+    if (i == code.size()) {
+        return true;
+    }
+
+    if (code[i] != '_') {
+        return false;
+    }
+    ++i;
+
+    const size_t region_start = i;
+    while (i < code.size() && isUpper(code[i])) {
+        ++i;
+    }
+    if (i - region_start != 2) {
+        return false;
+    }
+
+    return i == code.size();
+}
+
+std::vector<std::string> scanInstalledLocales(const std::filesystem::path& translations_dir) {
+    std::vector<std::string> result;
+
+    std::error_code ec;
+    if (!std::filesystem::is_directory(translations_dir, ec)) {
+        return result;
+    }
+
+    for (const auto& entry : std::filesystem::directory_iterator(translations_dir, ec)) {
+        if (ec) {
+            break;
+        }
+        if (!entry.is_regular_file(ec)) {
+            continue;
+        }
+        const auto name = entry.path().filename().string();
+        if (name.size() <= kFilenamePrefix.size() + kFilenameSuffix.size()) {
+            continue;
+        }
+        if (!std::string_view{name}.starts_with(kFilenamePrefix)) {
+            continue;
+        }
+        if (!std::string_view{name}.ends_with(kFilenameSuffix)) {
+            continue;
+        }
+        std::string code =
+            name.substr(kFilenamePrefix.size(), name.size() - kFilenamePrefix.size() - kFilenameSuffix.size());
+        if (!isValidLocaleCode(code)) {
+            continue;
+        }
+        result.push_back(std::move(code));
+    }
+
+    std::ranges::sort(result);
+    const auto trim = std::ranges::unique(result);
+    result.erase(trim.begin(), trim.end());
+    return result;
+}
+
+}  // namespace sudoku::core

--- a/src/core/locale_utils.h
+++ b/src/core/locale_utils.h
@@ -1,0 +1,47 @@
+// sudoku-cpp - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sudoku::core {
+
+/// Validate a BCP 47 locale code subset: 2-3 lowercase language letters,
+/// optionally followed by `_<2 uppercase letters>` (region).
+///
+/// Equivalent regex: ^[a-z]{2,3}(_[A-Z]{2})?$
+///
+/// Script subtags (e.g. `sr_Latn`) are intentionally not supported — Qt's
+/// .ts/.qm tooling produces language-or-region forms by default and no
+/// installed translation relies on a script subtag. If that ever changes,
+/// loosen this gate at the same time.
+///
+/// Reject anything else, including path separators, shell metacharacters, and
+/// embedded NULs. Used as a gate before any locale code reaches the
+/// filesystem via `sudoku_<code>.qm` lookups, so it must be conservative.
+[[nodiscard]] bool isValidLocaleCode(std::string_view code) noexcept;
+
+/// Scan `translations_dir` (non-recursive) for `sudoku_<code>.qm` files and
+/// return the sorted, deduplicated list of valid locale codes found. Filenames
+/// whose code fails `isValidLocaleCode` are silently skipped. Returns an empty
+/// vector if the directory does not exist.
+[[nodiscard]] std::vector<std::string> scanInstalledLocales(const std::filesystem::path& translations_dir);
+
+}  // namespace sudoku::core

--- a/src/core/settings_manager.cpp
+++ b/src/core/settings_manager.cpp
@@ -17,6 +17,7 @@
 #include "settings_manager.h"
 
 #include "infrastructure/app_directory_manager.h"
+#include "locale_utils.h"
 
 #include <algorithm>
 #include <fstream>
@@ -44,6 +45,20 @@ namespace {
             return "Master";
         default:
             return "Medium";
+    }
+}
+
+void loadLanguageField(const YAML::Node& root, Settings& settings, const std::filesystem::path& path) {
+    auto v = root["language"];
+    if (!v) {
+        return;
+    }
+    auto code = v.as<std::string>();
+    if (isValidLocaleCode(code)) {
+        settings.language = std::move(code);
+    } else {
+        spdlog::warn("Ignoring invalid 'language' value '{}' in {}; keeping default '{}'", code, path.string(),
+                     settings.language);
     }
 }
 
@@ -128,6 +143,10 @@ void SettingsManager::setEncryptDetailedStats(bool value) {
 }
 
 void SettingsManager::setLanguage(std::string_view locale_code) {
+    if (!isValidLocaleCode(locale_code)) {
+        spdlog::warn("Rejected invalid locale code '{}' from setLanguage()", locale_code);
+        return;
+    }
     auto old = settings_;
     settings_.language = std::string(locale_code);
     notifyIfChanged(old);
@@ -192,9 +211,7 @@ void SettingsManager::load() {
             // auto_notes_on_startup: ignored (feature removed)
         }
 
-        if (auto v = root["language"]) {
-            settings_.language = v.as<std::string>();
-        }
+        loadLanguageField(root, settings_, settings_path_);
 
         if (auto experimental = root["experimental"]) {
             if (auto v = experimental["training_mode"]) {
@@ -263,6 +280,10 @@ void SettingsManager::migrateLanguageFile() {
     std::ifstream in(language_file);
     std::string locale_code;
     if (in && std::getline(in, locale_code) && !locale_code.empty()) {
+        if (!isValidLocaleCode(locale_code)) {
+            spdlog::warn("Ignoring invalid locale code '{}' in legacy language.txt", locale_code);
+            return;
+        }
         settings_.language = locale_code;
         save();
         spdlog::info("Migrated language preference '{}' from language.txt to settings.yaml", locale_code);

--- a/src/view/locale_utils.cpp
+++ b/src/view/locale_utils.cpp
@@ -43,9 +43,9 @@ std::vector<LocaleEntry> discoverInstalledLocales() {
 
     // "en" is the source language: even with no .qm files, the UI still works
     // in English. Guarantee it appears in the combo.
-    if (std::find(codes.begin(), codes.end(), "en") == codes.end()) {
+    if (std::ranges::find(codes, "en") == codes.end()) {
         codes.emplace_back("en");
-        std::sort(codes.begin(), codes.end());
+        std::ranges::sort(codes);
     }
 
     std::vector<LocaleEntry> entries;
@@ -56,7 +56,7 @@ std::vector<LocaleEntry> discoverInstalledLocales() {
         if (display.isEmpty()) {
             display = QString::fromStdString(code);
         }
-        entries.push_back({std::move(code), std::move(display)});
+        entries.push_back({.code = std::move(code), .native_name = std::move(display)});
     }
     return entries;
 }

--- a/src/view/locale_utils.cpp
+++ b/src/view/locale_utils.cpp
@@ -1,0 +1,64 @@
+// sudoku-cpp - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "locale_utils.h"
+
+#include "../core/locale_utils.h"
+
+#include <algorithm>
+
+#include <QCoreApplication>
+#include <QLocale>
+
+namespace sudoku::view {
+
+std::filesystem::path findTranslationsDir() {
+    const auto exe_dir = std::filesystem::path(QCoreApplication::applicationDirPath().toStdString());
+    for (const auto& candidate : {exe_dir / "translations", exe_dir / ".." / "share" / "sudoku" / "translations"}) {
+        if (std::filesystem::exists(candidate)) {
+            return candidate;
+        }
+    }
+    return {};
+}
+
+std::vector<LocaleEntry> discoverInstalledLocales() {
+    std::vector<std::string> codes;
+    if (auto dir = findTranslationsDir(); !dir.empty()) {
+        codes = core::scanInstalledLocales(dir);
+    }
+
+    // "en" is the source language: even with no .qm files, the UI still works
+    // in English. Guarantee it appears in the combo.
+    if (std::find(codes.begin(), codes.end(), "en") == codes.end()) {
+        codes.emplace_back("en");
+        std::sort(codes.begin(), codes.end());
+    }
+
+    std::vector<LocaleEntry> entries;
+    entries.reserve(codes.size());
+    for (auto& code : codes) {
+        QLocale qlocale(QString::fromStdString(code));
+        QString display = qlocale.nativeLanguageName();
+        if (display.isEmpty()) {
+            display = QString::fromStdString(code);
+        }
+        entries.push_back({std::move(code), std::move(display)});
+    }
+    return entries;
+}
+
+}  // namespace sudoku::view

--- a/src/view/locale_utils.h
+++ b/src/view/locale_utils.h
@@ -1,0 +1,44 @@
+// sudoku-cpp - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <QString>
+
+namespace sudoku::view {
+
+struct LocaleEntry {
+    std::string code;
+    QString native_name;
+};
+
+/// Resolve the directory containing `sudoku_<code>.qm` files. Checks the
+/// build-tree layout (next to the executable) first, then the FHS install
+/// layout (`../share/sudoku/translations`). Returns an empty path if neither
+/// exists.
+[[nodiscard]] std::filesystem::path findTranslationsDir();
+
+/// Build the list of locales offered in the Settings combo. Combines a
+/// filesystem scan of `findTranslationsDir()` with `QLocale::nativeLanguageName()`
+/// for display strings, and always includes `"en"` (the source language)
+/// even if no `.qm` files were found. Entries are sorted by code.
+[[nodiscard]] std::vector<LocaleEntry> discoverInstalledLocales();
+
+}  // namespace sudoku::view

--- a/src/view/main_window.cpp
+++ b/src/view/main_window.cpp
@@ -19,8 +19,10 @@
 #include "core/constants.h"
 #include "core/i18n_helpers.h"
 #include "core/i_game_validator.h"
+#include "core/locale_utils.h"
 #include "core/observable.h"
 #include "infrastructure/app_directory_manager.h"
+#include "locale_utils.h"
 #include "model/game_state.h"
 #include "puzzle_import_dialog.h"
 #include "puzzle_technique_dialog.h"
@@ -650,16 +652,16 @@ void MainWindow::setSettingsManager(std::shared_ptr<core::ISettingsManager> sett
 }
 
 void MainWindow::applyLocale(const std::string& locale_code) {
-    // Locate sudoku_<locale>.qm next to the executable (dev/Windows layout)
-    // or under ../share/sudoku/translations (FHS install).
-    auto exe_dir = std::filesystem::path(QCoreApplication::applicationDirPath().toStdString());
-    std::filesystem::path translations_dir;
-    for (const auto& candidate : {exe_dir / "translations", exe_dir / ".." / "share" / "sudoku" / "translations"}) {
-        if (std::filesystem::exists(candidate)) {
-            translations_dir = candidate;
-            break;
-        }
+    // Defense in depth: by the time we reach here the code has already been
+    // validated by SettingsManager, but applyLocale interpolates `locale_code`
+    // into a path passed to QTranslator::load(). Rejecting bad codes here
+    // closes the loop if a future caller skips the SettingsManager gate.
+    if (!core::isValidLocaleCode(locale_code)) {
+        spdlog::warn("Rejected invalid locale code '{}' in applyLocale", locale_code);
+        return;
     }
+
+    auto translations_dir = findTranslationsDir();
 
     QCoreApplication::removeTranslator(&translator_);
 
@@ -1480,12 +1482,11 @@ void MainWindow::showSettingsDialog() {
         auto* lang_layout = new QHBoxLayout();
         lang_layout->addWidget(new QLabel(qstr(core::loc("Sudoku", "Language"))));
         auto* lang_combo = new QComboBox();
-        static const std::array<std::pair<const char*, const char*>, 2> kLocales = {
-            {{"en", "English"}, {"de", "Deutsch"}}};
+        const auto locales = discoverInstalledLocales();
         int current_idx = 0;
-        for (size_t i = 0; i < kLocales.size(); ++i) {
-            lang_combo->addItem(QString::fromUtf8(kLocales[i].second), QString::fromUtf8(kLocales[i].first));
-            if (kLocales[i].first == settings_manager_->getSettings().language) {
+        for (size_t i = 0; i < locales.size(); ++i) {
+            lang_combo->addItem(locales[i].native_name, QString::fromStdString(locales[i].code));
+            if (locales[i].code == settings_manager_->getSettings().language) {
                 current_idx = static_cast<int>(i);
             }
         }

--- a/tests/unit/test_locale_utils.cpp
+++ b/tests/unit/test_locale_utils.cpp
@@ -131,13 +131,12 @@ TEST_CASE("scanInstalledLocales rejects invalid locale codes in filenames", "[lo
     CHECK(result[0] == "en");
 }
 
-TEST_CASE("scanInstalledLocales deduplicates if a code appears twice", "[locale]") {
+TEST_CASE("scanInstalledLocales is non-recursive", "[locale]") {
     sudoku::test::TempTestDir tmp;
     auto sub = tmp.path() / "sub";
     std::filesystem::create_directory(sub);
     touch(tmp.path() / "sudoku_en.qm");
-    touch(sub / "sudoku_en.qm");
-    // Non-recursive scan: subdir entry must not leak in.
+    touch(sub / "sudoku_de.qm");
 
     auto result = scanInstalledLocales(tmp.path());
 

--- a/tests/unit/test_locale_utils.cpp
+++ b/tests/unit/test_locale_utils.cpp
@@ -1,0 +1,146 @@
+// sudoku-cpp - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "../../src/core/locale_utils.h"
+#include "../helpers/test_utils.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <catch2/catch_test_macros.hpp>
+
+using sudoku::core::isValidLocaleCode;
+using sudoku::core::scanInstalledLocales;
+
+TEST_CASE("isValidLocaleCode accepts BCP 47 subset", "[locale]") {
+    CHECK(isValidLocaleCode("en"));
+    CHECK(isValidLocaleCode("de"));
+    CHECK(isValidLocaleCode("ru"));
+    CHECK(isValidLocaleCode("fil"));    // 3-letter language
+    CHECK(isValidLocaleCode("zh_CN"));  // language + region
+    CHECK(isValidLocaleCode("pt_BR"));
+}
+
+TEST_CASE("isValidLocaleCode rejects malformed codes", "[locale]") {
+    CHECK_FALSE(isValidLocaleCode(""));
+    CHECK_FALSE(isValidLocaleCode("e"));        // too short
+    CHECK_FALSE(isValidLocaleCode("englsh"));   // too long (6 lowercase)
+    CHECK_FALSE(isValidLocaleCode("EN"));       // wrong case
+    CHECK_FALSE(isValidLocaleCode("en_de"));    // region must be uppercase
+    CHECK_FALSE(isValidLocaleCode("en_"));      // trailing underscore
+    CHECK_FALSE(isValidLocaleCode("en_C"));     // region too short
+    CHECK_FALSE(isValidLocaleCode("en_USA"));   // region too long
+    CHECK_FALSE(isValidLocaleCode("sr_Latn"));  // script subtags not supported
+    CHECK_FALSE(isValidLocaleCode("en-US"));    // hyphen, not underscore
+    CHECK_FALSE(isValidLocaleCode("en US"));    // space
+    CHECK_FALSE(isValidLocaleCode("en.de"));    // dot
+    CHECK_FALSE(isValidLocaleCode("en/de"));    // slash
+}
+
+TEST_CASE("isValidLocaleCode blocks path-traversal payloads", "[locale][security]") {
+    CHECK_FALSE(isValidLocaleCode("../../etc/passwd"));
+    CHECK_FALSE(isValidLocaleCode(".."));
+    CHECK_FALSE(isValidLocaleCode("../en"));
+    CHECK_FALSE(isValidLocaleCode("en;rm -rf /"));
+    // String with embedded NUL: real attack would smuggle bytes past a C-string boundary.
+    std::string with_nul = "en";
+    with_nul.push_back('\0');
+    with_nul += "evil";
+    CHECK_FALSE(isValidLocaleCode(with_nul));
+    CHECK_FALSE(isValidLocaleCode("\xff\xfe"));  // non-ASCII bytes
+    std::string very_long(10000, 'a');
+    CHECK_FALSE(isValidLocaleCode(very_long));
+}
+
+namespace {
+
+void touch(const std::filesystem::path& p) {
+    std::ofstream out(p);
+}
+
+}  // namespace
+
+TEST_CASE("scanInstalledLocales returns empty list for missing dir", "[locale]") {
+    sudoku::test::TempTestDir tmp;
+    auto missing = tmp.path() / "does_not_exist";
+    auto result = scanInstalledLocales(missing);
+    CHECK(result.empty());
+}
+
+TEST_CASE("scanInstalledLocales returns empty list for empty dir", "[locale]") {
+    sudoku::test::TempTestDir tmp;
+    auto result = scanInstalledLocales(tmp.path());
+    CHECK(result.empty());
+}
+
+TEST_CASE("scanInstalledLocales finds sudoku_<code>.qm files", "[locale]") {
+    sudoku::test::TempTestDir tmp;
+    touch(tmp.path() / "sudoku_en.qm");
+    touch(tmp.path() / "sudoku_de.qm");
+    touch(tmp.path() / "sudoku_ru.qm");
+    touch(tmp.path() / "sudoku_zh_CN.qm");
+
+    auto result = scanInstalledLocales(tmp.path());
+
+    REQUIRE(result.size() == 4);
+    // Output is sorted alphabetically for determinism
+    CHECK(result[0] == "de");
+    CHECK(result[1] == "en");
+    CHECK(result[2] == "ru");
+    CHECK(result[3] == "zh_CN");
+}
+
+TEST_CASE("scanInstalledLocales ignores non-matching files", "[locale]") {
+    sudoku::test::TempTestDir tmp;
+    touch(tmp.path() / "sudoku_en.qm");
+    touch(tmp.path() / "sudoku.qm");         // no locale
+    touch(tmp.path() / "sudoku_.qm");        // empty locale
+    touch(tmp.path() / "readme.txt");        // wrong extension
+    touch(tmp.path() / "other_en.qm");       // wrong prefix
+    touch(tmp.path() / "sudoku_en.qm.bak");  // wrong suffix
+
+    auto result = scanInstalledLocales(tmp.path());
+
+    REQUIRE(result.size() == 1);
+    CHECK(result[0] == "en");
+}
+
+TEST_CASE("scanInstalledLocales rejects invalid locale codes in filenames", "[locale][security]") {
+    sudoku::test::TempTestDir tmp;
+    touch(tmp.path() / "sudoku_en.qm");
+    touch(tmp.path() / "sudoku_EN.qm");     // wrong case
+    touch(tmp.path() / "sudoku_en-US.qm");  // hyphen
+    touch(tmp.path() / "sudoku_evil$.qm");  // shell metacharacter
+
+    auto result = scanInstalledLocales(tmp.path());
+
+    REQUIRE(result.size() == 1);
+    CHECK(result[0] == "en");
+}
+
+TEST_CASE("scanInstalledLocales deduplicates if a code appears twice", "[locale]") {
+    sudoku::test::TempTestDir tmp;
+    auto sub = tmp.path() / "sub";
+    std::filesystem::create_directory(sub);
+    touch(tmp.path() / "sudoku_en.qm");
+    touch(sub / "sudoku_en.qm");
+    // Non-recursive scan: subdir entry must not leak in.
+
+    auto result = scanInstalledLocales(tmp.path());
+
+    REQUIRE(result.size() == 1);
+    CHECK(result[0] == "en");
+}

--- a/tests/unit/test_settings_manager.cpp
+++ b/tests/unit/test_settings_manager.cpp
@@ -306,6 +306,53 @@ TEST_CASE("SettingsManager - No migration if settings.yaml already exists", "[se
     CHECK(mgr.getSettings().language == "en");
 }
 
+TEST_CASE("SettingsManager - setLanguage rejects invalid codes", "[settings][security]") {
+    sudoku::test::TempTestDir tmp;
+    auto path = tmp.path() / "settings.yaml";
+
+    SettingsManager mgr(path);
+    REQUIRE(mgr.getSettings().language == "en");
+
+    mgr.setLanguage("../../tmp/evil");
+    CHECK(mgr.getSettings().language == "en");
+
+    mgr.setLanguage("EN");
+    CHECK(mgr.getSettings().language == "en");
+
+    mgr.setLanguage("");
+    CHECK(mgr.getSettings().language == "en");
+
+    // Valid code is still accepted.
+    mgr.setLanguage("de");
+    CHECK(mgr.getSettings().language == "de");
+}
+
+TEST_CASE("SettingsManager - YAML with bogus language falls back to default", "[settings][security]") {
+    sudoku::test::TempTestDir tmp;
+    auto path = tmp.path() / "settings.yaml";
+
+    {
+        std::ofstream out(path);
+        out << "language: \"../etc/passwd\"\n";
+    }
+
+    SettingsManager mgr(path);
+    CHECK(mgr.getSettings().language == "en");
+}
+
+TEST_CASE("SettingsManager - language.txt migration rejects invalid code", "[settings][security]") {
+    sudoku::test::TempTestDir tmp;
+    auto path = tmp.path() / "settings.yaml";
+
+    {
+        std::ofstream out(tmp.path() / "language.txt");
+        out << "../../";
+    }
+
+    SettingsManager mgr(path);
+    CHECK(mgr.getSettings().language == "en");
+}
+
 TEST_CASE("SettingsManager - All difficulty values round-trip", "[settings]") {
     sudoku::test::TempTestDir tmp;
     auto path = tmp.path() / "settings.yaml";


### PR DESCRIPTION
## Summary

- Replace the hardcoded `{en, de}` Settings combo with a runtime scan of `sudoku_<code>.qm` files in the resolved translations dir. Packagers can ship a new locale by dropping a `.ts` file into `resources/translations/` and adding a matching `CMakeLists.txt` entry — no C++ change required.
- Validate every write path into `Settings::language` (setter, `settings.yaml` load, legacy `language.txt` migration, `applyLocale()`) against a conservative BCP 47 subset: `^[a-z]{2,3}(_[A-Z]{2})?$`. Closes the path-traversal vector where a hand-edited config could smuggle `../etc/passwd`-style segments into `QTranslator::load()`.
- Split helpers cleanly: Qt-free core (`src/core/locale_utils.*`) for unit-testability, Qt-aware view wrapper (`src/view/locale_utils.*`) for `QLocale::nativeLanguageName()` and translations-dir resolution.

## Test plan

- [x] `./build/RelWithDebInfo/bin/tests/unit_tests` — all 1001 cases / 15,037 assertions pass, including 9 new `[locale]` cases with 39 assertions (positive codes, malformed codes, path traversal, embedded NUL, non-ASCII bytes, 10k-char input, hostile YAML, hostile `language.txt`).
- [x] `./scripts/tidy-diff.sh main` — clean modulo documented v22 tech debt (`cppcoreguidelines-pro-bounds-avoid-unchecked-container-access`, suppress policy per `docs/CODE_QUALITY.md`).
- [x] CHANGELOG `[Unreleased]` entry added covering both the packager workflow and the security gate.
- [ ] Manual: launch the app on a build with `sudoku_de.qm` present → Settings combo shows "English" and "Deutsch"; on a build without `.qm` files → combo still shows "English" (fallback).
- [ ] Manual: hand-edit `settings.yaml` with `language: "../etc/passwd"` → startup logs a warning, language falls back to `en`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)