### PR TITLE
fix(save): allow Master-difficulty saves to load (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ First tagged release (in preparation). Adds the custom-puzzle feature suite on t
 
 - **Manual "Analyze Difficulty" menu action.** Auto-rating makes it obsolete — every playable puzzle is now rated at creation time (or loaded with its rating from a save). Retry would have been a placebo anyway since `scoreDifficulty` is deterministic on a given board.
 
+### Fixed
+
+- **Master-difficulty saves now load correctly.** Previously the save loader's range check hardcoded `MAX_DIFFICULTY = 3` (Expert), so every Master save (difficulty 4) was silently rejected with `InvalidSaveData` — permanent data loss for Master-difficulty games. The range now tracks the `Difficulty` enum end-to-end. Existing saves that would not load before this fix will load after it. (#11)
+
 ### Internal
 
 - New `IPuzzleAnalyzer` interface (`parseString`, `serializeToString`, `validate`, `checkUniqueness`, `scoreDifficulty`) backs all custom-puzzle workflows.

--- a/src/core/save_manager_serialization.cpp
+++ b/src/core/save_manager_serialization.cpp
@@ -47,9 +47,11 @@ namespace {
 // backward compatibility (regression-tested in test_save_origin_integration.cpp).
 inline constexpr const char* SAVE_FILE_VERSION = "1.1";
 
-// Difficulty validation constants (min/max values for range checking)
-inline constexpr int MIN_DIFFICULTY = 0;  // Easy
-inline constexpr int MAX_DIFFICULTY = 3;  // Expert
+// Difficulty validation constants (min/max values for range checking).
+// MUST track the Difficulty enum in i_puzzle_generator.h; a hardcoded Expert
+// bound silently rejected every Master save (see #11 / BL-8).
+inline constexpr int MIN_DIFFICULTY = static_cast<int>(sudoku::core::Difficulty::Easy);
+inline constexpr int MAX_DIFFICULTY = static_cast<int>(sudoku::core::Difficulty::Master);
 
 // Zlib compression magic bytes
 // All zlib compressed data starts with 0x78 followed by a compression level indicator

--- a/tests/unit/test_save_manager_deserialization.cpp
+++ b/tests/unit/test_save_manager_deserialization.cpp
@@ -163,7 +163,7 @@ TEST_CASE("SaveManager - deserialize: invalid difficulty value → InvalidSaveDa
                        "created_time: 1000000000\n"
                        "last_modified: 1000000000\n"
                        "puzzle_data:\n"
-                       "  difficulty: 99\n"  // invalid: only 0-3 are valid
+                       "  difficulty: 99\n"  // invalid: only 0-4 are valid (Easy..Master)
                        "  puzzle_seed: 1\n";
     yaml += nineRowBoard("original_puzzle");
     yaml += nineRowBoard("current_state");
@@ -173,6 +173,36 @@ TEST_CASE("SaveManager - deserialize: invalid difficulty value → InvalidSaveDa
     auto result = mgr.loadGame("bad-difficulty");
     REQUIRE_FALSE(result.has_value());
     REQUIRE(result.error() == SaveError::InvalidSaveData);
+}
+
+// ============================================================================
+// Master difficulty (4) must load successfully (regression: #11 / BL-8)
+// Before the fix, MAX_DIFFICULTY = 3 (Expert) caused Master saves to be
+// rejected with InvalidSaveData — permanent data loss for Master-difficulty
+// games. See docs/CODE_REVIEW_2026-05-25.md §BL-8.
+// ============================================================================
+
+TEST_CASE("SaveManager - deserialize: Master difficulty (4) loads successfully",
+          "[save_manager_deser][regression][bug-master-save-rejected]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    std::string yaml = "version: '1.0'\n"
+                       "save_id: master-save\n"
+                       "display_name: Master Game\n"
+                       "created_time: 1000000000\n"
+                       "last_modified: 1000000000\n"
+                       "puzzle_data:\n"
+                       "  difficulty: 4\n"  // Difficulty::Master
+                       "  puzzle_seed: 1\n";
+    yaml += nineRowBoard("original_puzzle");
+    yaml += nineRowBoard("current_state");
+
+    writeYaml(tmp.path(), "master-save", yaml);
+
+    auto result = mgr.loadGame("master-save");
+    REQUIRE(result.has_value());
+    REQUIRE(result.value().difficulty == Difficulty::Master);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- `MAX_DIFFICULTY` was hardcoded to `3` (Expert) in `save_manager_serialization.cpp`, so every Master save (difficulty `4`) was silently rejected with `InvalidSaveData` — permanent data loss for Master-difficulty games.
- Derive `MIN_DIFFICULTY` / `MAX_DIFFICULTY` from the `Difficulty` enum (`Easy` / `Master`) so the loader can never drift from the enum end-to-end.
- Added regression test tagged `[regression][bug-master-save-rejected]` that proves Red on `HEAD~1` and Green on the fix.

## Test plan

- [x] New regression test fails against `HEAD~1` with `Invalid difficulty value: 4` → `InvalidSaveData`.
- [x] New regression test passes after the fix; the save loads with `difficulty == Difficulty::Master`.
- [x] Full unit suite green: **1004 test cases, 15,050 assertions, all passing**.
- [x] Pre-commit hook (license headers + clang-format) clean.

## Notes

- One-line code change + 1-line static_cast + reason comment in source; the rest is the regression test (32 lines) and the `### Fixed` CHANGELOG entry.
- The neighbouring "invalid difficulty value (99)" test still passes — `99` is invalid regardless of the new max.
- This is item **B4** of the 5-item starting wedge from the 2026-05-25 review triage (see `docs/CODE_REVIEW_2026-05-25.md` §BL-8).

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)