### PR TITLE
fix(simd): gate AVX-512 dispatch on BITALG sub-feature (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ First tagged release (in preparation). Adds the custom-puzzle feature suite on t
 ### Fixed
 
 - **Master-difficulty saves now load correctly.** Previously the save loader's range check hardcoded `MAX_DIFFICULTY = 3` (Expert), so every Master save (difficulty 4) was silently rejected with `InvalidSaveData` — permanent data loss for Master-difficulty games. The range now tracks the `Difficulty` enum end-to-end. Existing saves that would not load before this fix will load after it. (#11)
+- **AVX-512 dispatch now requires the BITALG sub-feature.** The solver's AVX-512 path issues `_mm512_popcnt_epi16` (in `findMRVCell`), which requires AVX-512 BITALG — present on Zen 5+ and Ice Lake-SP+, but missing on Skylake-X / Cascade Lake / Zen 4. Previously the dispatch gate only checked AVX-512F + AVX-512BW, so these CPUs were selected onto the AVX-512 path and crashed with SIGILL on first popcount. Detection now reads CPUID(7,0).ECX bit 12 and dispatch falls back to AVX2 (or scalar) when BITALG is absent. (#17)
 
 ### Internal
 

--- a/src/core/cpu_features.cpp
+++ b/src/core/cpu_features.cpp
@@ -116,9 +116,13 @@ namespace {
     }
 
     // EBX bit 16: AVX-512F, bit 30: AVX-512BW (requires OS AVX-512 support)
+    // ECX bit 12: AVX-512 BITALG — required for `_mm512_popcnt_epi16` used in
+    // findMRVCell. Skylake-X / Cascade Lake / Zen 4 have F+BW but no BITALG;
+    // dispatch onto those CPUs without this gate would SIGILL (#17 / BL-1).
     if (osSupportsAvx512()) {
         features.has_avx512f = (ebx & (1U << 16)) != 0;
         features.has_avx512bw = (ebx & (1U << 30)) != 0;
+        features.has_avx512_bitalg = (ecx & (1U << 12)) != 0;
     }
 
     return features;

--- a/src/core/cpu_features.h
+++ b/src/core/cpu_features.h
@@ -27,10 +27,11 @@ namespace sudoku::core {
  * Scalar/AVX2/AVX512 code paths based on the running CPU.
  */
 struct CpuFeatures {
-    bool has_avx2{false};      ///< AVX2 (256-bit SIMD)
-    bool has_avx512f{false};   ///< AVX-512 Foundation
-    bool has_avx512bw{false};  ///< AVX-512 Byte/Word
-    bool has_popcnt{false};    ///< Hardware POPCNT instruction
+    bool has_avx2{false};           ///< AVX2 (256-bit SIMD)
+    bool has_avx512f{false};        ///< AVX-512 Foundation
+    bool has_avx512bw{false};       ///< AVX-512 Byte/Word
+    bool has_avx512_bitalg{false};  ///< AVX-512 BITALG (`_mm512_popcnt_epi16`, Zen 5+ / Ice Lake-SP+)
+    bool has_popcnt{false};         ///< Hardware POPCNT instruction
 };
 
 /**
@@ -52,12 +53,29 @@ struct CpuFeatures {
 }
 
 /**
- * @brief Convenience: is AVX-512 available at runtime?
- * @return true if CPU supports AVX-512F + AVX-512BW and OS enables AVX-512 state saving
+ * @brief Logic-only AVX-512 availability check on a given feature set.
+ *
+ * The project's AVX-512 path issues `_mm512_popcnt_epi16` (`findMRVCell`), which
+ * requires the BITALG sub-feature in addition to AVX-512F + AVX-512BW. Without
+ * the BITALG gate, dispatch onto Skylake-X / Cascade Lake / Zen 4 (F+BW present,
+ * BITALG absent) crashes with SIGILL on first popcount. See #17 / BL-1.
+ *
+ * Exposed as an overload taking the feature struct so the gate logic is unit-
+ * testable independently of the running CPU.
+ *
+ * @return true iff F + BW + BITALG are all present
+ */
+[[nodiscard]] constexpr bool hasAvx512(const CpuFeatures& features) noexcept {
+    return features.has_avx512f && features.has_avx512bw && features.has_avx512_bitalg;
+}
+
+/**
+ * @brief Convenience: is AVX-512 available at runtime on this CPU?
+ * @return true if the running CPU supports AVX-512F + AVX-512BW + AVX-512BITALG
+ *         and the OS enables AVX-512 state saving
  */
 [[nodiscard]] inline bool hasAvx512() {
-    const auto& features = getCpuFeatures();
-    return features.has_avx512f && features.has_avx512bw;
+    return hasAvx512(getCpuFeatures());
 }
 
 /// Solver SIMD path selection for benchmarking and forced dispatch.

--- a/tests/unit/test_cpu_features.cpp
+++ b/tests/unit/test_cpu_features.cpp
@@ -33,6 +33,7 @@ TEST_CASE("CPU feature detection", "[cpu_features]") {
         REQUIRE(f1.has_avx2 == f2.has_avx2);
         REQUIRE(f1.has_avx512f == f2.has_avx512f);
         REQUIRE(f1.has_avx512bw == f2.has_avx512bw);
+        REQUIRE(f1.has_avx512_bitalg == f2.has_avx512_bitalg);
         REQUIRE(f1.has_popcnt == f2.has_popcnt);
     }
 
@@ -50,10 +51,12 @@ TEST_CASE("CPU feature detection", "[cpu_features]") {
         REQUIRE((features.has_popcnt == true || features.has_popcnt == false));
         REQUIRE((features.has_avx512f == true || features.has_avx512f == false));
         REQUIRE((features.has_avx512bw == true || features.has_avx512bw == false));
+        REQUIRE((features.has_avx512_bitalg == true || features.has_avx512_bitalg == false));
     }
 
     SECTION("hasAvx512 convenience matches struct fields") {
-        auto expected = getCpuFeatures().has_avx512f && getCpuFeatures().has_avx512bw;
+        const auto& f = getCpuFeatures();
+        auto expected = f.has_avx512f && f.has_avx512bw && f.has_avx512_bitalg;
         REQUIRE(hasAvx512() == expected);
     }
 
@@ -63,10 +66,48 @@ TEST_CASE("CPU feature detection", "[cpu_features]") {
             REQUIRE(getCpuFeatures().has_avx512f);
         }
 
-        // hasAvx512() should only be true if both F and BW are present
+        // hasAvx512() must require F + BW + BITALG
         if (hasAvx512()) {
             REQUIRE(getCpuFeatures().has_avx512f);
             REQUIRE(getCpuFeatures().has_avx512bw);
+            REQUIRE(getCpuFeatures().has_avx512_bitalg);
         }
+    }
+}
+
+// =============================================================================
+// Regression test: AVX-512 dispatch must require BITALG (#17 / BL-1)
+//
+// Before the fix, hasAvx512() returned true on any CPU with F + BW, but the
+// AVX-512 SIMD path issues _mm512_popcnt_epi16 which requires BITALG. On
+// Skylake-X / Cascade Lake / Zen 4 (F + BW present, BITALG absent), dispatch
+// crashed with SIGILL. The logic is now testable via the const-ref overload.
+// See docs/CODE_REVIEW_2026-05-25.md §BL-1.
+// =============================================================================
+
+TEST_CASE("hasAvx512(features) — BITALG gate", "[cpu_features][regression][bug-avx512-bitalg-ungated]") {
+    SECTION("all three present -> true") {
+        const CpuFeatures f{.has_avx512f = true, .has_avx512bw = true, .has_avx512_bitalg = true};
+        REQUIRE(hasAvx512(f));
+    }
+
+    SECTION("F + BW without BITALG -> false (the Skylake-X / Cascade Lake / Zen 4 case)") {
+        const CpuFeatures f{.has_avx512f = true, .has_avx512bw = true, .has_avx512_bitalg = false};
+        REQUIRE_FALSE(hasAvx512(f));
+    }
+
+    SECTION("F + BITALG without BW -> false") {
+        const CpuFeatures f{.has_avx512f = true, .has_avx512bw = false, .has_avx512_bitalg = true};
+        REQUIRE_FALSE(hasAvx512(f));
+    }
+
+    SECTION("BW + BITALG without F -> false") {
+        const CpuFeatures f{.has_avx512f = false, .has_avx512bw = true, .has_avx512_bitalg = true};
+        REQUIRE_FALSE(hasAvx512(f));
+    }
+
+    SECTION("default-constructed (all false) -> false") {
+        const CpuFeatures f{};
+        REQUIRE_FALSE(hasAvx512(f));
     }
 }


### PR DESCRIPTION
## Summary

- The AVX-512 SIMD path issues `_mm512_popcnt_epi16` (in `findMRVCell`), which requires AVX-512 **BITALG** — present on Zen 5+ and Ice Lake-SP+, missing on Skylake-X / Cascade Lake / Zen 4.
- The previous dispatch gate only checked AVX-512F + AVX-512BW, so these CPUs would select the AVX-512 path and **SIGILL** on the first popcount call.
- Detection now reads CPUID(7,0).ECX bit 12 into a new `CpuFeatures::has_avx512_bitalg` field. The dispatch gate (now exposed as a unit-testable `hasAvx512(const CpuFeatures&)` overload) requires all three: F + BW + BITALG.

## Test plan

- [x] Added 5 regression assertions tagged `[regression][bug-avx512-bitalg-ungated]` covering: all-three-present, F+BW without BITALG (the bug case), F+BITALG without BW, BW+BITALG without F, default-constructed.
- [x] **Red proved manually:** temporarily removed `&& f.has_avx512_bitalg` from the overload — the "F + BW without BITALG → false" assertion failed with `REQUIRE_FALSE(true)`. Restoring the check returned all tests to Green.
- [x] Existing `[cpu_features]` tests updated to include BITALG in struct-equality and consistency checks; still pass.
- [x] Full unit suite green: **1004 cases, 15,056 assertions, all passing**.
- [x] Pre-commit hook (license + clang-format) clean.

## Notes

- The new logic-only overload `hasAvx512(const CpuFeatures&)` is `constexpr noexcept` and pure — it makes the dispatch gate testable independently of the running CPU.
- No existing callers needed changes: `solution_counter.cpp`, `cpu_features.h::isSolverPathAvailable`, and `test_solver_path.cpp` continue to call the no-arg `hasAvx512()` which now delegates to the overload via `getCpuFeatures()`.
- Item **B5** of the 5-item starting wedge from the 2026-05-25 review triage. See `docs/CODE_REVIEW_2026-05-25.md` §BL-1.
- The CHANGELOG `### Fixed` section will conflict on merge with PR #31; trivial resolution (both entries under one section).

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)