### PR TITLE
fix(save): cap decompression at 64 MiB to defuse zlib bombs (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ First tagged release (in preparation). Adds the custom-puzzle feature suite on t
 
 - **Manual "Analyze Difficulty" menu action.** Auto-rating makes it obsolete — every playable puzzle is now rated at creation time (or loaded with its rating from a save). Retry would have been a placebo anyway since `scoreDifficulty` is deterministic on a given board.
 
+### Security
+
+- **Save-file decompression is now capped at 64 MiB.** Previously the zlib decompression loop could allocate up to ~4096× the compressed input before giving up — a crafted 10 MiB save file could demand ~40 GiB of RAM and crash the process via OOM. The cap is far above any realistic save (YAML saves are typically <1 MiB) but small enough to keep the decompressor's memory bounded; oversized inputs are now rejected with `CompressionError`. Affects both regular save loading and `importSave`. (#12)
+
 ### Fixed
 
 - **Master-difficulty saves now load correctly.** Previously the save loader's range check hardcoded `MAX_DIFFICULTY = 3` (Expert), so every Master save (difficulty 4) was silently rejected with `InvalidSaveData` — permanent data loss for Master-difficulty games. The range now tracks the `Difficulty` enum end-to-end. Existing saves that would not load before this fix will load after it. (#11)

--- a/src/core/save_manager_compression.cpp
+++ b/src/core/save_manager_compression.cpp
@@ -36,6 +36,12 @@ inline constexpr int DEFAULT_COMPRESSION_LEVEL = 6;
 inline constexpr int INITIAL_DECOMPRESSION_MULTIPLIER = 4;
 inline constexpr int MAX_DECOMPRESSION_ATTEMPTS = 10;
 inline constexpr int BUFFER_SIZE_MULTIPLIER = 2;
+// Maximum allowed uncompressed size — decompression-bomb protection (#12 / BL-9).
+// A YAML save is typically <1 MiB; 64 MiB is far above any realistic save while
+// being small enough to fit in memory on any platform we support. Without this
+// cap, the doubling loop below could allocate up to data.size() * 4096 (~40 GiB
+// for a 10 MiB input) before giving up.
+inline constexpr size_t MAX_DECOMPRESSED_SIZE = 64UL * 1024 * 1024;
 }  // namespace
 
 namespace sudoku::core {
@@ -71,21 +77,30 @@ std::expected<std::vector<uint8_t>, SaveError> SaveManager::decompressData(const
         return std::vector<uint8_t>{};
     }
 
-    // Start with initial multiplier of compressed size as initial guess
-    auto uncompressed_size = static_cast<uLongf>(data.size() * INITIAL_DECOMPRESSION_MULTIPLIER);
+    // Start with initial multiplier of compressed size, clamped to the bomb cap.
+    auto uncompressed_size =
+        static_cast<uLongf>(std::min<size_t>(data.size() * INITIAL_DECOMPRESSION_MULTIPLIER, MAX_DECOMPRESSED_SIZE));
     std::vector<uint8_t> uncompressed(uncompressed_size);
 
     int result = Z_BUF_ERROR;
     int attempts = 0;
 
-    // Try decompression with increasing buffer sizes
+    // Try decompression with increasing buffer sizes, refusing to grow past the cap.
     while (result == Z_BUF_ERROR && attempts < MAX_DECOMPRESSION_ATTEMPTS) {
         result = uncompress(uncompressed.data(), &uncompressed_size, data.data(), static_cast<uLong>(data.size()));
 
         if (result == Z_BUF_ERROR) {
-            // Buffer too small, double it
-            uncompressed_size *= BUFFER_SIZE_MULTIPLIER;
-            uncompressed.resize(uncompressed_size);
+            // Refuse to grow past the decompression-bomb cap.
+            if (uncompressed.size() >= MAX_DECOMPRESSED_SIZE) {
+                spdlog::error("Decompression refused: would exceed max size {} bytes after {} attempts "
+                              "(likely a zlib bomb)",
+                              MAX_DECOMPRESSED_SIZE, attempts);
+                return std::unexpected(SaveError::CompressionError);
+            }
+            // Buffer too small, double it (clamped to the cap).
+            auto new_size = std::min<size_t>(uncompressed.size() * BUFFER_SIZE_MULTIPLIER, MAX_DECOMPRESSED_SIZE);
+            uncompressed.resize(new_size);
+            uncompressed_size = static_cast<uLongf>(new_size);
             ++attempts;
         }
     }

--- a/tests/unit/test_save_manager_compression.cpp
+++ b/tests/unit/test_save_manager_compression.cpp
@@ -19,10 +19,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
+#include <zlib.h>
 
 using namespace sudoku::core;
 using sudoku::test::TempTestDir;
@@ -306,6 +309,56 @@ TEST_CASE("Compression handles empty game data", "[save_manager][compression]") 
             REQUIRE(loaded_game.current_state[row][col] == 0);
         }
     }
+}
+
+// =============================================================================
+// Regression: decompressData refuses zlib bombs (#12 / BL-9)
+//
+// Before the fix, the decompression loop doubled the output buffer up to
+// 10 times starting from data.size() * 4 — i.e., it would allocate up to
+// 4096x the compressed input before giving up. A 10 MB crafted blob can
+// demand ~40 GB of memory. The fix adds an absolute MAX_DECOMPRESSED_SIZE
+// cap (64 MiB) so the loop refuses to grow past the cap and returns
+// CompressionError instead of attempting an unbounded allocation.
+// See docs/CODE_REVIEW_2026-05-25.md §BL-9.
+// =============================================================================
+
+TEST_CASE("Decompression refuses zlib bombs above the cap",
+          "[save_manager][compression][regression][bug-zlib-decompression-bomb]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // Build a 65 MiB block of zeros — one byte above the 64 MiB cap.
+    // Zeros compress to a few-hundred-byte zlib stream (~1000:1 ratio),
+    // so the on-disk "bomb" file stays tiny while the decompressed
+    // payload would blow past the cap. The 65 MiB plaintext is also small
+    // enough to be allocatable by `compress2` on any CI runner.
+    constexpr size_t kBombPlaintextBytes = (64UL * 1024 * 1024) + (1UL * 1024 * 1024);  // 65 MiB
+    std::vector<uint8_t> plaintext(kBombPlaintextBytes, 0);
+
+    uLongf compressed_size = compressBound(static_cast<uLong>(plaintext.size()));
+    std::vector<uint8_t> compressed(compressed_size);
+    const int rc = compress2(compressed.data(), &compressed_size, plaintext.data(),
+                             static_cast<uLong>(plaintext.size()), Z_DEFAULT_COMPRESSION);
+    REQUIRE(rc == Z_OK);
+    compressed.resize(compressed_size);
+    REQUIRE(compressed.size() < 1UL * 1024 * 1024);  // sanity: small on disk
+
+    // Drop the plaintext to free the 65 MiB before the decompressor runs.
+    plaintext = std::vector<uint8_t>{};
+
+    // Write as an unencrypted save file. Deserialization will sniff the
+    // zlib magic byte and route into decompressData.
+    auto bomb_path = tmp.path() / "bomb.yaml";
+    {
+        std::ofstream f(bomb_path, std::ios::binary);
+        REQUIRE(f.is_open());
+        f.write(reinterpret_cast<const char*>(compressed.data()), static_cast<std::streamsize>(compressed.size()));
+    }
+
+    auto result = mgr.loadGame("bomb");
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error() == SaveError::CompressionError);
 }
 
 TEST_CASE("Decompression handles malformed data", "[save_manager][compression]") {


### PR DESCRIPTION
## Summary

- `decompressData` doubled the output buffer up to **10 times** from `data.size() * 4` — i.e. it could allocate up to **~4096× the compressed input** before giving up. A crafted 10 MiB blob could demand ~40 GiB of RAM and OOM-crash the process.
- Reachable via both regular `loadGame` (for any unencrypted save with valid zlib magic + level byte) and `importSave`.
- Add `MAX_DECOMPRESSED_SIZE = 64 MiB`. The initial buffer is clamped to that cap, and the doubling loop refuses to grow past it — returns `SaveError::CompressionError` instead.
- 64 MiB is **far above** any realistic save (YAML saves are typically <1 MiB) but bounds the decompressor's memory tightly.

## Test plan

- [x] New regression test tagged `[regression][bug-zlib-decompression-bomb]` builds a real 65 MiB zlib stream of zeros (a few-hundred-byte payload on disk via zlib's `compress2`), writes it as `bomb.yaml`, and asserts `loadGame` returns `CompressionError`.
- [x] **Red proved on HEAD~1:** the unfixed decompressor successfully expanded the 65 MiB bomb, then YAML parsing on 65 MiB of zero bytes returned `SerializationError` (8) — exactly the wrong error path. Test fails with `result.error() == 8` ≠ `CompressionError` (9).
- [x] After fix: `decompressData` refuses at attempt 8 when growing past 64 MiB → `CompressionError` → test passes.
- [x] Full unit suite green: **1004 cases, 15,053 assertions, all passing**.
- [x] Pre-commit hook (license + clang-format) clean.

## Notes

- The cap value (64 MiB) is generous. If a real save ever approaches it, that signals a separate problem (move-history bloat) and is the right place to surface it.
- Other zlib-touching paths (`compressData`, `isValidSaveFile`) are unchanged.
- Item **B6** of the 5-item starting wedge from the 2026-05-25 review triage. See `docs/CODE_REVIEW_2026-05-25.md` §BL-9.
- CHANGELOG entry under `### Security` (security-flavored DoS protection). Will need trivial merge resolution alongside PR #31 and #32 (both add `### Fixed`).

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)