### PR TITLE
fix(core): make PuzzleAnalyzer fully-formed by construction (BL-7, #41)

### DIFF
--- a/src/core/puzzle_analyzer.h
+++ b/src/core/puzzle_analyzer.h
@@ -20,6 +20,7 @@
 #include "i_game_validator.h"
 #include "i_sudoku_solver.h"
 
+#include <cassert>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -123,29 +124,27 @@ protected:
 };
 
 /// Concrete puzzle analyzer. Wraps an IGameValidator (rule conflicts), an ISudokuSolver
-/// (scoring via solve path), and a SolutionCounter (uniqueness). Each dependency is optional
-/// for partial setups — parsing/serializing only require no deps.
+/// (scoring via solve path), and a SolutionCounter (uniqueness). All three dependencies are
+/// REQUIRED and non-null: every method except parseString/serializeToString dereferences them
+/// unconditionally, so there is a single constructor and the analyzer is never partially
+/// initialized. Previously a default ctor plus partial-dep ctors advertised "optional for
+/// partial setups," but the methods had no precondition checks — calling, say, validate() on a
+/// default-constructed instance segfaulted (BL-7, code review 2026-05-25). That state is now
+/// unrepresentable; if tiered construction is ever genuinely needed, split the interface rather
+/// than reintroducing nullable members.
 class PuzzleAnalyzer : public IPuzzleAnalyzer {
 public:
     /// Max input size accepted by parseString. Larger inputs short-circuit with InputTooLarge.
     static constexpr std::size_t kMaxInputBytes = 4096;
 
-    /// Default constructor — supports parseString/serializeToString without any deps.
-    PuzzleAnalyzer() = default;
-
-    /// Constructor with validator for the validate() method.
-    explicit PuzzleAnalyzer(std::shared_ptr<IGameValidator> validator) : validator_(std::move(validator)) {
-    }
-
-    /// Constructor with validator and solution counter for validate() + checkUniqueness().
-    PuzzleAnalyzer(std::shared_ptr<IGameValidator> validator, std::shared_ptr<SolutionCounter> counter)
-        : validator_(std::move(validator)), counter_(std::move(counter)) {
-    }
-
-    /// Full constructor — required for scoreDifficulty().
+    /// Sole constructor — all three dependencies are required and must be non-null. In practice
+    /// they are process-wide DI singletons (see main.cpp), so the full set is always available at
+    /// every call site at zero extra cost. The assert documents the invariant and fails fast in
+    /// debug builds if a caller wires up a null dependency (e.g. a misconfigured DI registration).
     PuzzleAnalyzer(std::shared_ptr<IGameValidator> validator, std::shared_ptr<ISudokuSolver> solver,
                    std::shared_ptr<SolutionCounter> counter)
         : validator_(std::move(validator)), solver_(std::move(solver)), counter_(std::move(counter)) {
+        assert(validator_ && solver_ && counter_ && "PuzzleAnalyzer requires non-null validator, solver, and counter");
     }
 
     /// Parses a paste-string into a BoardData. See ParseError for the full ruleset.

--- a/tests/unit/test_puzzle_analyzer.cpp
+++ b/tests/unit/test_puzzle_analyzer.cpp
@@ -26,13 +26,37 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
 using namespace sudoku::core;
 
+TEST_CASE("PuzzleAnalyzer construction contract — all deps required", "[puzzle_analyzer][contract]") {
+    // BL-7 (code review 2026-05-25): every method except parseString/serializeToString
+    // dereferences validator_/solver_/counter_ unconditionally. A default- or partially-
+    // constructed analyzer therefore segfaults on first use of an unsupported method, even
+    // though the header used to advertise partial setups as safe. The fix makes that state
+    // unrepresentable: the sole constructor takes the full dependency set, so the type system
+    // — not a runtime precondition check nobody wrote — guarantees the object is fully formed.
+    STATIC_REQUIRE_FALSE(std::is_default_constructible_v<PuzzleAnalyzer>);
+    STATIC_REQUIRE_FALSE(std::is_constructible_v<PuzzleAnalyzer, std::shared_ptr<IGameValidator>>);
+    STATIC_REQUIRE_FALSE(
+        std::is_constructible_v<PuzzleAnalyzer, std::shared_ptr<IGameValidator>, std::shared_ptr<SolutionCounter>>);
+    STATIC_REQUIRE(std::is_constructible_v<PuzzleAnalyzer, std::shared_ptr<IGameValidator>,
+                                           std::shared_ptr<ISudokuSolver>, std::shared_ptr<SolutionCounter>>);
+}
+
 namespace {
+
+// Builds a fully-wired analyzer — the only valid construction path post-BL-7. Used by the
+// parse/serialize/validate/uniqueness tests, none of which exercise more than a subset of the
+// deps but all of which must construct a complete object.
+PuzzleAnalyzer makeFullAnalyzer() {
+    auto validator = std::make_shared<GameValidator>();
+    return PuzzleAnalyzer{validator, std::make_shared<SudokuSolver>(validator), std::make_shared<SolutionCounter>()};
+}
 
 // 81-char canonical "easy" puzzle (the same naked-single fixture from solver tests).
 constexpr std::string_view kEasyDigits = "034678912"
@@ -54,7 +78,7 @@ BoardData makeEasyBoard() {
 }  // namespace
 
 TEST_CASE("PuzzleAnalyzer::parseString — happy paths", "[puzzle_analyzer][parser]") {
-    PuzzleAnalyzer analyzer;
+    auto analyzer = makeFullAnalyzer();
 
     SECTION("81 chars, digits with 0 for empty") {
         auto result = analyzer.parseString(kEasyDigits);
@@ -128,7 +152,7 @@ TEST_CASE("PuzzleAnalyzer::parseString — happy paths", "[puzzle_analyzer][pars
 }
 
 TEST_CASE("PuzzleAnalyzer::parseString — rejection paths", "[puzzle_analyzer][parser]") {
-    PuzzleAnalyzer analyzer;
+    auto analyzer = makeFullAnalyzer();
 
     SECTION("80 chars → WrongLength{actual=80}") {
         std::string input{kEasyDigits.substr(0, 80)};
@@ -194,7 +218,7 @@ TEST_CASE("PuzzleAnalyzer::parseString — rejection paths", "[puzzle_analyzer][
 }
 
 TEST_CASE("PuzzleAnalyzer::serializeToString round-trip", "[puzzle_analyzer][parser][roundtrip]") {
-    PuzzleAnalyzer analyzer;
+    auto analyzer = makeFullAnalyzer();
 
     SECTION("Serialize uses '.' for empty and produces exactly 81 chars") {
         BoardData board = makeEasyBoard();
@@ -230,8 +254,7 @@ namespace {
 }  // namespace
 
 TEST_CASE("PuzzleAnalyzer::validate — happy paths", "[puzzle_analyzer][validate]") {
-    auto validator = std::make_shared<GameValidator>();
-    PuzzleAnalyzer analyzer(validator);
+    auto analyzer = makeFullAnalyzer();
 
     SECTION("Empty board is trivially valid") {
         BoardData empty;
@@ -247,8 +270,7 @@ TEST_CASE("PuzzleAnalyzer::validate — happy paths", "[puzzle_analyzer][validat
 }
 
 TEST_CASE("PuzzleAnalyzer::validate — conflict reporting", "[puzzle_analyzer][validate]") {
-    auto validator = std::make_shared<GameValidator>();
-    PuzzleAnalyzer analyzer(validator);
+    auto analyzer = makeFullAnalyzer();
 
     SECTION("Row conflict: two 5s in row 0 → both cells flagged") {
         BoardData board;
@@ -283,9 +305,7 @@ TEST_CASE("PuzzleAnalyzer::validate — conflict reporting", "[puzzle_analyzer][
 }
 
 TEST_CASE("PuzzleAnalyzer::checkUniqueness", "[puzzle_analyzer][uniqueness]") {
-    auto validator = std::make_shared<GameValidator>();
-    auto counter = std::make_shared<SolutionCounter>();
-    PuzzleAnalyzer analyzer(validator, counter);
+    auto analyzer = makeFullAnalyzer();
 
     SECTION("Generated puzzle has unique solution") {
         PuzzleGenerator generator;


### PR DESCRIPTION
Closes #41.

## Problem

`PuzzleAnalyzer` advertised *"each dependency is optional for partial setups"* and exposed a default ctor plus 1- and 2-arg partial-dep ctors. But every method except `parseString`/`serializeToString` dereferences `validator_`/`solver_`/`counter_` with **no precondition checks**:

- `validate()` → `validator_->findConflicts(board)` ([puzzle_analyzer.cpp:116](src/core/puzzle_analyzer.cpp#L116))
- `checkUniqueness()` → `counter_->clearCache()` ([puzzle_analyzer.cpp:125](src/core/puzzle_analyzer.cpp#L125))
- `scoreDifficulty()` → `solver_->solvePuzzle(...)` ([puzzle_analyzer.cpp:149](src/core/puzzle_analyzer.cpp#L149))

So `PuzzleAnalyzer{}.validate(board)` is a guaranteed SIGSEGV — the header contract and the implementation directly contradicted each other (BL-7, flagged BLOCKER in the 2026-05-25 code review but never tracked).

## Why it was never hit

The crash is **purely latent**. `git log -S` confirms production `src/` never used a partial ctor — [main.cpp](src/main.cpp) wired the full 3-arg ctor from the analyzer's first commit. All three deps are **independent, process-wide DI singletons** (shared by the solver, rater, ViewModel, training generator, …), so they always exist and the analyzer factory just resolves them at zero extra cost. The tiers' only payoff — cheap partial construction — never materializes in this app. The partial ctors were inert and used only by tier-matched unit tests.

## Fix (Option B — make the invalid state unrepresentable)

- **[puzzle_analyzer.h](src/core/puzzle_analyzer.h):** drop the default + 1-arg + 2-arg ctors; keep a single full ctor with `assert(validator_ && solver_ && counter_)` as a fail-fast guard against an explicitly-null dep; rewrite the class doc to state deps are required; add `<cassert>`.
- **[test_puzzle_analyzer.cpp](tests/unit/test_puzzle_analyzer.cpp):** add a construction-contract test (`STATIC_REQUIRE` — only the full dep set is constructible) authored TDD red→green; add a `makeFullAnalyzer()` helper and repoint the 6 partial-ctor sites at it.

If tiered construction is ever genuinely needed, the right tool is **interface segregation**, not reintroducing nullable members.

## Testing

- Unit: 1033 cases / 15452 assertions ✅
- Integration: 14 cases / 269 assertions ✅
- New analyzer contract test passes; full `[puzzle_analyzer]` group (8 cases / 86 assertions) green.

## CHANGELOG

Deliberately **skipped** — internal API-robustness fix on a path unreachable in production; no user- or packager-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)