### PR TITLE
fix(core): make DIContainer fail loudly on missing/cyclic resolution (#29)

### DIFF
--- a/src/core/di_container.h
+++ b/src/core/di_container.h
@@ -47,9 +47,10 @@ public:
     using DIContainerError::DIContainerError;
 };
 
-/// Thrown by resolve<T>() / tryResolve<T>() when a singleton factory
-/// transitively resolves its own type (a dependency cycle). Detected before
-/// the duplicate instance can be cached.
+/// Thrown by resolve<T>() / tryResolve<T>() when a factory transitively
+/// resolves its own type (a dependency cycle). For a singleton this is detected
+/// before the duplicate instance can be cached; for a transient it stops the
+/// otherwise-unbounded recursion before it overflows the stack.
 class DICycleError : public DIContainerError {
 public:
     using DIContainerError::DIContainerError;
@@ -109,7 +110,7 @@ public:
 
     /// Resolve a dependency of type T, or return nullptr if it was never
     /// registered. Unlike resolve<T>(), an absent registration is not an error.
-    /// Cyclic singleton factories still throw DICycleError.
+    /// Cyclic factories still throw DICycleError.
     template <typename T>
     [[nodiscard]] std::shared_ptr<T> tryResolve() {
         return std::static_pointer_cast<T>(resolveErased(std::type_index(typeid(T))).instance);
@@ -143,29 +144,40 @@ private:
         std::shared_ptr<void> instance;
     };
 
-    /// RAII marker that records a singleton type as "resolution in progress"
-    /// and clears it on scope exit — including during exception unwinding — so
-    /// a detected cycle never leaves a type stuck in the in-progress set.
+    /// RAII marker that records a type as "resolution in progress". It inserts
+    /// on construction and exposes whether the insert was fresh via inserted();
+    /// a false result means the type was already being resolved — i.e. a cycle.
+    /// The marker is cleared on scope exit (including during exception
+    /// unwinding), but only by the guard that actually inserted it, so a thrown
+    /// cycle never erases the outer in-progress entry it shares.
     class ResolvingGuard {
     public:
-        ResolvingGuard(std::unordered_set<std::type_index>& set, std::type_index id) : set_(set), id_(id) {
+        ResolvingGuard(std::unordered_set<std::type_index>& set, std::type_index id)
+            : set_(set), id_(id), inserted_(set.insert(id).second) {
         }
         ResolvingGuard(const ResolvingGuard&) = delete;
         ResolvingGuard& operator=(const ResolvingGuard&) = delete;
         ResolvingGuard(ResolvingGuard&&) = delete;
         ResolvingGuard& operator=(ResolvingGuard&&) = delete;
         ~ResolvingGuard() {
-            set_.erase(id_);
+            if (inserted_) {
+                set_.erase(id_);
+            }
+        }
+
+        [[nodiscard]] bool inserted() const {
+            return inserted_;
         }
 
     private:
         std::unordered_set<std::type_index>& set_;
         std::type_index id_;
+        bool inserted_;
     };
 
     /// Shared resolution logic for resolve<T>() and tryResolve<T>(), operating
-    /// on the erased type_index. Throws DICycleError on re-entrant singleton
-    /// factory resolution.
+    /// on the erased type_index. Throws DICycleError on re-entrant factory
+    /// resolution (singleton or transient).
     ResolveResult resolveErased(std::type_index type_id) {
         // Check for existing singleton instance
         auto instance_it = instances_.find(type_id);
@@ -176,6 +188,13 @@ private:
         // Check for transient factory
         auto transient_it = transient_factories_.find(type_id);
         if (transient_it != transient_factories_.end()) {
+            // A transient factory that re-enters its own type would recurse
+            // until the stack overflows; the in-progress marker turns that into
+            // a clear throw instead.
+            ResolvingGuard guard(resolving_, type_id);
+            if (!guard.inserted()) {
+                throw DICycleError(std::string("DIContainer: cyclic transient resolution for type ") + type_id.name());
+            }
             return {.registered = true, .instance = transient_it->second()};
         }
 
@@ -185,10 +204,10 @@ private:
             // Mark in-progress before invoking the factory. A re-entrant resolve
             // of the same type (a cycle) would otherwise re-run the factory and
             // overwrite the cached instance, yielding two divergent "singletons".
-            if (!resolving_.insert(type_id).second) {
+            ResolvingGuard guard(resolving_, type_id);
+            if (!guard.inserted()) {
                 throw DICycleError(std::string("DIContainer: cyclic singleton resolution for type ") + type_id.name());
             }
-            ResolvingGuard guard(resolving_, type_id);
 
             auto instance = factory_it->second();
             instances_[type_id] = instance;  // Cache for future use
@@ -213,6 +232,13 @@ extern DIContainer& getContainer();
 template <typename T>
 [[nodiscard]] std::shared_ptr<T> resolve() {
     return getContainer().resolve<T>();
+}
+
+/// Convenience function for optional dependencies: returns nullptr if the type
+/// was never registered instead of throwing (see DIContainer::tryResolve).
+template <typename T>
+[[nodiscard]] std::shared_ptr<T> tryResolve() {
+    return getContainer().tryResolve<T>();
 }
 
 }  // namespace sudoku::core

--- a/src/core/di_container.h
+++ b/src/core/di_container.h
@@ -19,12 +19,41 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <typeindex>
+#include <typeinfo>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace sudoku::core {
+
+/// Base class for all DIContainer wiring errors.
+///
+/// These represent programmer errors in the dependency graph (a missing
+/// registration or a cyclic factory), not recoverable runtime conditions —
+/// hence an exception rather than std::expected. They fail loudly at the
+/// resolution site instead of returning a silent nullptr that segfaults later.
+class DIContainerError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+/// Thrown by resolve<T>() when no registration exists for the requested type.
+class DIResolutionError : public DIContainerError {
+public:
+    using DIContainerError::DIContainerError;
+};
+
+/// Thrown by resolve<T>() / tryResolve<T>() when a singleton factory
+/// transitively resolves its own type (a dependency cycle). Detected before
+/// the duplicate instance can be cached.
+class DICycleError : public DIContainerError {
+public:
+    using DIContainerError::DIContainerError;
+};
 
 /// Simple dependency injection container for managing object lifetimes
 class DIContainer {
@@ -60,32 +89,30 @@ public:
         };
     }
 
-    /// Resolve a dependency of type T
+    /// Resolve a dependency of type T.
+    ///
+    /// Contract: T must have been registered (singleton, transient, or
+    /// instance) before resolution. A missing registration is a wiring bug, so
+    /// this throws DIResolutionError rather than returning a silent nullptr
+    /// that would segfault far from the omission site. A singleton factory that
+    /// transitively resolves its own type throws DICycleError before the
+    /// duplicate instance can be cached. Use tryResolve<T>() for genuinely
+    /// optional dependencies where absence is expected.
     template <typename T>
-    std::shared_ptr<T> resolve() {
-        auto type_id = std::type_index(typeid(T));
-
-        // Check for existing singleton instance
-        auto instance_it = instances_.find(type_id);
-        if (instance_it != instances_.end()) {
-            return std::static_pointer_cast<T>(instance_it->second);
+    [[nodiscard]] std::shared_ptr<T> resolve() {
+        auto resolution = resolveErased(std::type_index(typeid(T)));
+        if (!resolution.registered) {
+            throw DIResolutionError(std::string("DIContainer: no registration for type ") + typeid(T).name());
         }
+        return std::static_pointer_cast<T>(std::move(resolution.instance));
+    }
 
-        // Check for transient factory
-        auto transient_it = transient_factories_.find(type_id);
-        if (transient_it != transient_factories_.end()) {
-            return std::static_pointer_cast<T>(transient_it->second());
-        }
-
-        // Check for singleton factory
-        auto factory_it = factories_.find(type_id);
-        if (factory_it != factories_.end()) {
-            auto instance = factory_it->second();
-            instances_[type_id] = instance;  // Cache for future use
-            return std::static_pointer_cast<T>(instance);
-        }
-
-        return nullptr;
+    /// Resolve a dependency of type T, or return nullptr if it was never
+    /// registered. Unlike resolve<T>(), an absent registration is not an error.
+    /// Cyclic singleton factories still throw DICycleError.
+    template <typename T>
+    [[nodiscard]] std::shared_ptr<T> tryResolve() {
+        return std::static_pointer_cast<T>(resolveErased(std::type_index(typeid(T))).instance);
     }
 
     /// Check if a type is registered
@@ -108,18 +135,83 @@ public:
     }
 
 private:
+    /// Outcome of a type-erased lookup. `registered` distinguishes "no
+    /// registration" (resolve throws, tryResolve returns null) from a
+    /// registered factory that legitimately produced a null instance.
+    struct ResolveResult {
+        bool registered;
+        std::shared_ptr<void> instance;
+    };
+
+    /// RAII marker that records a singleton type as "resolution in progress"
+    /// and clears it on scope exit — including during exception unwinding — so
+    /// a detected cycle never leaves a type stuck in the in-progress set.
+    class ResolvingGuard {
+    public:
+        ResolvingGuard(std::unordered_set<std::type_index>& set, std::type_index id) : set_(set), id_(id) {
+        }
+        ResolvingGuard(const ResolvingGuard&) = delete;
+        ResolvingGuard& operator=(const ResolvingGuard&) = delete;
+        ResolvingGuard(ResolvingGuard&&) = delete;
+        ResolvingGuard& operator=(ResolvingGuard&&) = delete;
+        ~ResolvingGuard() {
+            set_.erase(id_);
+        }
+
+    private:
+        std::unordered_set<std::type_index>& set_;
+        std::type_index id_;
+    };
+
+    /// Shared resolution logic for resolve<T>() and tryResolve<T>(), operating
+    /// on the erased type_index. Throws DICycleError on re-entrant singleton
+    /// factory resolution.
+    ResolveResult resolveErased(std::type_index type_id) {
+        // Check for existing singleton instance
+        auto instance_it = instances_.find(type_id);
+        if (instance_it != instances_.end()) {
+            return {.registered = true, .instance = instance_it->second};
+        }
+
+        // Check for transient factory
+        auto transient_it = transient_factories_.find(type_id);
+        if (transient_it != transient_factories_.end()) {
+            return {.registered = true, .instance = transient_it->second()};
+        }
+
+        // Check for singleton factory
+        auto factory_it = factories_.find(type_id);
+        if (factory_it != factories_.end()) {
+            // Mark in-progress before invoking the factory. A re-entrant resolve
+            // of the same type (a cycle) would otherwise re-run the factory and
+            // overwrite the cached instance, yielding two divergent "singletons".
+            if (!resolving_.insert(type_id).second) {
+                throw DICycleError(std::string("DIContainer: cyclic singleton resolution for type ") + type_id.name());
+            }
+            ResolvingGuard guard(resolving_, type_id);
+
+            auto instance = factory_it->second();
+            instances_[type_id] = instance;  // Cache for future use
+            return {.registered = true, .instance = instance};
+        }
+
+        return {.registered = false, .instance = nullptr};
+    }
+
     std::unordered_map<std::type_index, std::shared_ptr<void>> instances_;
     std::unordered_map<std::type_index, std::function<std::shared_ptr<void>()>> factories_;
     std::unordered_map<std::type_index, std::function<std::shared_ptr<void>()>> transient_factories_;
+    std::unordered_set<std::type_index> resolving_;
 };
 
 /// Global container instance for easy access
 /// In a real application, consider using a different pattern for DI
 extern DIContainer& getContainer();
 
-/// Convenience function to resolve dependencies
+/// Convenience function to resolve dependencies. Throws DIResolutionError if
+/// the type was never registered (see DIContainer::resolve).
 template <typename T>
-std::shared_ptr<T> resolve() {
+[[nodiscard]] std::shared_ptr<T> resolve() {
     return getContainer().resolve<T>();
 }
 

--- a/tests/unit/test_di_container.cpp
+++ b/tests/unit/test_di_container.cpp
@@ -216,6 +216,51 @@ TEST_CASE("DIContainer - Cyclic singleton resolution", "[DIContainer]") {
         REQUIRE(dep != nullptr);
         REQUIRE(dep->getName() == "ok");
     }
+
+    SECTION("Transient self-cycle is detected and throws") {
+        // A transient factory that re-enters its own type would otherwise
+        // recurse until the stack overflows; the guard must turn it into a
+        // clear throw, just like the singleton path.
+        container.registerTransient<ITestService>([&container]() {
+            auto self = container.resolve<ITestService>();  // re-entry
+            return std::make_unique<TestService>(self ? self->getValue() : -1);
+        });
+
+        REQUIRE_THROWS_AS(container.resolve<ITestService>(), DICycleError);
+    }
+
+    SECTION("In-progress marker is cleared after a transient cycle throws") {
+        container.registerTransient<ITestService>([&container]() {
+            auto self = container.resolve<ITestService>();
+            return std::make_unique<TestService>(1);
+        });
+        container.registerSingleton<IDependency>([]() { return std::make_unique<Dependency>("ok"); });
+
+        REQUIRE_THROWS_AS(container.resolve<ITestService>(), DICycleError);
+
+        auto dep = container.resolve<IDependency>();
+        REQUIRE(dep != nullptr);
+        REQUIRE(dep->getName() == "ok");
+    }
+}
+
+TEST_CASE("DIContainer - Free-function resolve helpers", "[DIContainer]") {
+    auto& container = getContainer();
+    container.clear();
+
+    SECTION("Free tryResolve returns nullptr for unregistered service") {
+        REQUIRE(tryResolve<ITestService>() == nullptr);
+    }
+
+    SECTION("Free tryResolve returns the instance for a registered service") {
+        container.registerSingleton<ITestService>([]() { return std::make_unique<TestService>(7); });
+
+        auto service = tryResolve<ITestService>();
+        REQUIRE(service != nullptr);
+        REQUIRE(service->getValue() == 7);
+    }
+
+    container.clear();
 }
 
 TEST_CASE("DIContainer - Clear Services", "[DIContainer]") {

--- a/tests/unit/test_di_container.cpp
+++ b/tests/unit/test_di_container.cpp
@@ -17,6 +17,7 @@
 #include "core/di_container.h"
 
 #include <memory>
+#include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -131,9 +132,36 @@ TEST_CASE("DIContainer - Service Dependencies", "[DIContainer]") {
 TEST_CASE("DIContainer - Error Handling", "[DIContainer]") {
     DIContainer container;
 
-    SECTION("Resolve unregistered service returns nullptr") {
-        auto service = container.resolve<ITestService>();
+    SECTION("Resolve unregistered service throws DIResolutionError") {
+        REQUIRE_THROWS_AS(container.resolve<ITestService>(), DIResolutionError);
+    }
+
+    SECTION("Resolution error names the missing type") {
+        try {
+            static_cast<void>(container.resolve<ITestService>());
+            FAIL("expected DIResolutionError");
+        } catch (const DIResolutionError& ex) {
+            // Diagnostic must reference the unresolved type so wiring omissions
+            // are debuggable at the omission site, not at a far-away segfault.
+            const std::string message = ex.what();
+            REQUIRE(message.find(typeid(ITestService).name()) != std::string::npos);
+        }
+    }
+
+    SECTION("tryResolve returns nullptr for unregistered service") {
+        auto service = container.tryResolve<ITestService>();
         REQUIRE(service == nullptr);
+    }
+
+    SECTION("tryResolve returns the instance for a registered service") {
+        container.registerSingleton<ITestService>([]() { return std::make_unique<TestService>(7); });
+
+        auto via_try = container.tryResolve<ITestService>();
+        auto via_resolve = container.resolve<ITestService>();
+
+        REQUIRE(via_try != nullptr);
+        REQUIRE(via_try.get() == via_resolve.get());
+        REQUIRE(via_try->getValue() == 7);
     }
 
     SECTION("Check if service is registered") {
@@ -142,6 +170,51 @@ TEST_CASE("DIContainer - Error Handling", "[DIContainer]") {
         container.registerSingleton<ITestService>([]() { return std::make_unique<TestService>(1); });
 
         REQUIRE(container.isRegistered<ITestService>());
+    }
+}
+
+TEST_CASE("DIContainer - Cyclic singleton resolution", "[DIContainer]") {
+    DIContainer container;
+
+    SECTION("Direct self-cycle is detected and throws") {
+        // Factory for ITestService transitively resolves its own type before
+        // returning. Without re-entry detection this re-runs the factory and
+        // caches a duplicate instance; the guard must turn it into a clear throw.
+        container.registerSingleton<ITestService>([&container]() {
+            auto self = container.resolve<ITestService>();  // re-entry
+            return std::make_unique<TestService>(self ? self->getValue() : -1);
+        });
+
+        REQUIRE_THROWS_AS(container.resolve<ITestService>(), DICycleError);
+    }
+
+    SECTION("Mutual two-type cycle is detected and throws") {
+        container.registerSingleton<ITestService>([&container]() {
+            auto dep = container.resolve<IDependency>();
+            return std::make_unique<ServiceWithDependency>(dep);
+        });
+        container.registerSingleton<IDependency>([&container]() {
+            auto svc = container.resolve<ITestService>();
+            return std::make_unique<Dependency>(svc ? "x" : "y");
+        });
+
+        REQUIRE_THROWS_AS(container.resolve<ITestService>(), DICycleError);
+    }
+
+    SECTION("In-progress marker is cleared after a cycle throws") {
+        container.registerSingleton<ITestService>([&container]() {
+            auto self = container.resolve<ITestService>();
+            return std::make_unique<TestService>(1);
+        });
+        container.registerSingleton<IDependency>([]() { return std::make_unique<Dependency>("ok"); });
+
+        REQUIRE_THROWS_AS(container.resolve<ITestService>(), DICycleError);
+
+        // A subsequent well-formed resolution of a different type must still
+        // succeed: the failed type must not be left stuck in the in-progress set.
+        auto dep = container.resolve<IDependency>();
+        REQUIRE(dep != nullptr);
+        REQUIRE(dep->getName() == "ok");
     }
 }
 
@@ -156,8 +229,7 @@ TEST_CASE("DIContainer - Clear Services", "[DIContainer]") {
         container.clear();
 
         REQUIRE_FALSE(container.isRegistered<ITestService>());
-        auto service = container.resolve<ITestService>();
-        REQUIRE(service == nullptr);
+        REQUIRE_THROWS_AS(container.resolve<ITestService>(), DIResolutionError);
     }
 }
 

--- a/tests/unit/test_di_container.cpp
+++ b/tests/unit/test_di_container.cpp
@@ -129,6 +129,7 @@ TEST_CASE("DIContainer - Service Dependencies", "[DIContainer]") {
     }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with multiple REQUIRE/SECTION checks; complexity is inherent to test coverage
 TEST_CASE("DIContainer - Error Handling", "[DIContainer]") {
     DIContainer container;
 
@@ -173,6 +174,7 @@ TEST_CASE("DIContainer - Error Handling", "[DIContainer]") {
     }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with multiple REQUIRE/SECTION checks; complexity is inherent to test coverage
 TEST_CASE("DIContainer - Cyclic singleton resolution", "[DIContainer]") {
     DIContainer container;
 


### PR DESCRIPTION
## Summary

Hardens `DIContainer` against the two HIGH findings in issue #29 (CODE_REVIEW_2026-05-25 §5, chunk 12).

### Bug 1 — silent `nullptr` on unregistered resolve (was active)
`resolve<T>()` returned a silent `nullptr` when a type was never registered, turning wiring omissions into far-away segfaults (e.g. `main.cpp` dereferencing an unresolved `save_manager`). It now **throws `DIResolutionError`** naming the missing type. Added **`tryResolve<T>()`** for genuinely-optional dependencies (returns `nullptr`, no throw). Both `resolve` overloads are `[[nodiscard]]`.

### Bug 2 — singleton re-entry caches a duplicate (was latent)
`instances_` was only written *after* the factory returned, so a re-entrant/cyclic singleton factory re-ran and the outer store overwrote the inner one — yielding two divergent "singletons". Added a `resolving_` in-progress set, set via an RAII guard before each singleton factory runs, that **throws `DICycleError`** on re-entry. The guard clears the marker during exception unwinding, so a thrown cycle never wedges the container.

> Note on framing: the issue calls Bug 2 a "race." Given the project's single-threaded Qt constraint there is no thread race — the only reachable path is re-entrant/cyclic resolution on one thread, which the current wiring doesn't exercise (so this was latent). The guard turns it into a clear, immediate error.

Both failure modes are exception-based (not `std::abort`) so they are fail-fast **and** unit-testable. Exception hierarchy: `DIContainerError` → `DIResolutionError` / `DICycleError`, following the `std::runtime_error` precedent in `encryption_manager.cpp`. Contract documented inline in the header.

## Tests (TDD, written first)
- Unregistered `resolve` → `DIResolutionError`; message contains the type name
- `tryResolve` returns `nullptr` for unregistered, the instance for registered
- Direct self-cycle and mutual two-type cycle → `DICycleError`
- In-progress marker cleared after a cycle throws (subsequent resolve of another type still works)
- Existing happy-path singleton/transient/dependency tests stay green

## Verification
- Full Release build links; **`sudoku` app launches cleanly** (confirms all registrations present, no cycles)
- 1054 unit cases, 14 integration cases, 13 offscreen UI tests — all pass
- `scripts/format.sh` clean; pre-commit license + format hooks pass

## Notes
- No `main.cpp` call-site changes required (return type unchanged on success).
- **CHANGELOG: intentionally skipped** — internal robustness hardening, no user- or packager-visible behavior change.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)