### PR TITLE
fix(ci): dedupe push + pull_request runs via unified concurrency key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,18 @@ on:
 permissions:
   contents: read
 
-# Avoid running the same workflow twice on the same commit when a branch
-# is both pushed and has an open PR. Group by PR number when available,
-# otherwise by ref, so the push-triggered run is cancelled as soon as the
-# pull_request-triggered run starts on the same head.
+# Avoid running the same workflow twice on the same commit when a branch is
+# both pushed and has an open PR (GitHub fires `push` and `pull_request` for
+# the same head). Key the concurrency group on the head *branch name*, which
+# both events can resolve to the same string: `github.head_ref` is the PR
+# source branch (empty on push), `github.ref_name` is the pushed branch. With
+# a shared key, `cancel-in-progress` cancels whichever run started first.
+#
+# Note: the clang-tidy-diff job picks its diff base per event (PR base sha vs
+# merge-base on push). For a normal PR these are the same commit, so it does
+# not matter which event's run survives the cancellation.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

PRs trigger **two concurrent `CI` runs on the same commit**. When a feature branch with an open PR is pushed, GitHub fires both `push` and `pull_request` events, and `ci.yml` subscribes to both.

The existing concurrency group tried to dedupe but keyed on `pull_request.number || github.ref`, which evaluates **per-event**:

- `push` run → `pull_request.number` empty → group `ci-CI-refs/heads/<branch>`
- `pull_request` run → group `ci-CI-<PR#>`

Different keys → different buckets → neither cancels the other → 2× CI.

## Fix

Key the concurrency group on the head **branch name**, which both events resolve to the same string:

```yaml
group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
```

- `github.head_ref` = PR source branch (empty on push)
- `github.ref_name` = pushed branch

Shared key → `cancel-in-progress` cancels the redundant run. **Pre-PR push CI on feature branches is preserved.**

## Notes

- `clang-tidy-diff` picks its diff base per event (PR base sha vs merge-base on push); for a normal PR these are the same commit, so it doesn't matter which run survives. Documented inline.
- CI-config only — no CHANGELOG entry (invisible to end users and the packager).
- De-duplication is only observable on GitHub; this PR's own push-with-open-PR is the first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)