### PR TITLE
fix(solver): verify Franken/Mutant fish cover-overlap soundness (#21)

### DIFF
--- a/docs/CODE_REVIEW_2026-05-25.md
+++ b/docs/CODE_REVIEW_2026-05-25.md
@@ -1061,6 +1061,13 @@ Verbatim per-chunk findings, notes, and coverage from each subagent. Use these f
 - Why it matters: Allows pseudo-JE patterns where a base candidate has no S-cell anywhere — invariant violated, eliminations unsound.
 - Fix: After collecting T1/T2 candidates, require `(t1_mask | t2_mask) & base_mask == base_mask` (each base candidate appears in at least one of T1/T2).
 
+> **UPDATE 2026-05-30 (issue #21) — both HIGH fish findings VERIFIED SOUND; resolved as hardening.**
+> On close analysis the two HIGH items below are **not live correctness bugs**:
+> - **Franken Fish:** cover units are only ever the complementary line type (cols when base = rows+boxes, rows when base = cols+boxes); boxes are never cover-eligible. So a cover unit can never *equal* a base unit (different `UnitType`), and covers are mutually parallel lines that can never share a cell. Both degeneracies are impossible by construction.
+> - **Mutant Fish:** overlapping cover sets are **sound** (cover-set pigeonhole theorem). With base cells cell-disjoint (the real load-bearing check, already present), the N base houses give N *distinct* true positions; an eliminated cover-not-base cell Z would saturate one cover house, forcing those N trues into N−1 remaining cover houses — a contradiction, regardless of cover overlap. The suggested "reject cover overlap" fix would *discard valid Mutant fish and weaken the solver*, so it was deliberately **not** applied.
+>
+> Resolution: proof comments + `static_assert` on the cover bitmask width added to both strategies; deterministic overlapping-cover regression tests added (`test_mutant_fish_strategy.cpp`, `test_franken_fish_strategy.cpp`) plus a 1000-puzzle generative soundness sweep (`test_strategy_correctness.cpp`) — all green, zero wrong deductions. The two MEDs below are micro-optimizations with no soundness impact (the bit-width has margin: 27 units ≤ 32 bits).
+
 **[HIGH] Franken Fish: cover units may overlap base units (degenerate fish)**
 - File: `src/core/strategies/franken_fish_strategy.h:178-203, 282-316`
 - Issue: Bestiary calls out base-cell overlap (correctly checked at 228-234). But the symmetric danger — a cover unit equal to a base unit, or a cover unit whose cells fully overlap a base unit — is not rejected. Per Franken Fish definition, a chosen cover should not be one of the chosen bases.

--- a/src/core/strategies/franken_fish_strategy.h
+++ b/src/core/strategies/franken_fish_strategy.h
@@ -272,8 +272,10 @@ private:
                           const std::vector<struct UnitCells>& cover_units, const std::vector<size_t>& chosen_bases,
                           const std::vector<size_t>& base_cells, size_t target_size) {
         // For each base cell, compute which cover units contain it (as bitmask).
-        // Cover units here are only the complementary line type (at most BOARD_SIZE = 9 of them),
-        // so every bit index fits comfortably in uint16_t. (Issue #21 MED)
+        // Bitmask width = number of cover units. Franken covers are the complementary LINE type
+        // only (at most BOARD_SIZE = 9 of them), so one bit each fits a uint16_t. (Cf.
+        // mutant_fish_strategy.h, where covers may be any of the 27 units and a uint32_t is
+        // needed.) (Issue #21 MED)
         static_assert(BOARD_SIZE <= 16, "cover bitmask (uint16_t) must hold one bit per cover line");
         std::vector<uint16_t> cell_cover_masks(base_cells.size(), 0);
         for (size_t ci = 0; ci < base_cells.size(); ++ci) {

--- a/src/core/strategies/franken_fish_strategy.h
+++ b/src/core/strategies/franken_fish_strategy.h
@@ -158,6 +158,15 @@ private:
     // NOLINTNEXTLINE(readability-function-cognitive-complexity,readability-function-size) — base/cover enumeration; nesting is inherent
     [[nodiscard]] static std::optional<SolveStep>
     tryFrankenFishOrientation(const BoardData& board, const CandidateGrid& candidates, int digit, bool row_base) {
+        // Cover/base disjointness invariant (Issue #21): in this orientation the cover units are
+        // ALWAYS the complementary line type only (cols when base = rows+boxes, rows when base =
+        // cols+boxes) — boxes are never cover-eligible. Hence:
+        //   * a cover unit can never EQUAL a chosen base unit (different UnitType), and
+        //   * cover units are mutually parallel lines, so two covers can never share a cell.
+        // Both Franken degeneracies the review worried about are therefore impossible by
+        // construction; no explicit rejection is needed (the symmetric Mutant guard lives in
+        // mutant_fish_strategy.h::findCoverAndEliminate).
+        //
         // Base candidates: lines + boxes
         std::vector<UnitCells> base_units;
         for (size_t i = 0; i < BOARD_SIZE; ++i) {
@@ -262,7 +271,10 @@ private:
                           const std::vector<struct UnitCells>& base_units,
                           const std::vector<struct UnitCells>& cover_units, const std::vector<size_t>& chosen_bases,
                           const std::vector<size_t>& base_cells, size_t target_size) {
-        // For each base cell, compute which cover units contain it (as bitmask)
+        // For each base cell, compute which cover units contain it (as bitmask).
+        // Cover units here are only the complementary line type (at most BOARD_SIZE = 9 of them),
+        // so every bit index fits comfortably in uint16_t. (Issue #21 MED)
+        static_assert(BOARD_SIZE <= 16, "cover bitmask (uint16_t) must hold one bit per cover line");
         std::vector<uint16_t> cell_cover_masks(base_cells.size(), 0);
         for (size_t ci = 0; ci < base_cells.size(); ++ci) {
             for (size_t ui = 0; ui < cover_units.size(); ++ui) {

--- a/src/core/strategies/mutant_fish_strategy.h
+++ b/src/core/strategies/mutant_fish_strategy.h
@@ -305,8 +305,10 @@ private:
         }
 
         // For each base cell, compute which cover units (indexed into cover_indices) contain it.
-        // Use a 32-bit bitmask: at most 27 distinct units exist (9 rows + 9 cols + 9 boxes), so
-        // cover_indices never exceeds 27 entries and every bit index fits in uint32_t. (Issue #21 MED)
+        // Bitmask width = number of cover-eligible units. Mutant covers may be ANY of the 3 unit
+        // types (rows + cols + boxes), so up to BOARD_SIZE*3 = 27 units → one bit each fits a
+        // uint32_t. (Cf. franken_fish_strategy.h, where covers are complementary lines only and a
+        // uint16_t suffices.) (Issue #21 MED)
         static_assert(BOARD_SIZE * 3 <= 32, "cover bitmask (uint32_t) must hold one bit per unit");
         std::vector<uint32_t> cell_cover_masks(base_cells.size(), 0);
         for (size_t ci_idx = 0; ci_idx < cover_indices.size(); ++ci_idx) {
@@ -335,11 +337,16 @@ private:
         if (chosen_cover_idx_positions.size() == target_size) {
             // Soundness note (Issue #21): overlapping cover sets are SOUND and are deliberately
             // allowed (rejecting them would discard valid Mutant fish and weaken the solver).
-            // The base cells are cell-disjoint (checked in enumerateBaseCombinations), so the N base
-            // houses contribute N *distinct* true positions of the digit, all inside the cover region.
-            // Suppose an eliminated cell Z (in cover, not in base) were the digit: Z occupies one
-            // cover house Cj, saturating it. The N distinct base-trues must then fall in the other
-            // N-1 cover houses (each holding at most one digit) — N pigeons, N-1 holes → contradiction.
+            // Rigorous counting argument (handles shared cover cells without hand-waving):
+            //   * In ANY full solution, each of the N cover houses contains the digit exactly once.
+            //     A cell lying in two cover houses is one true serving both, so the cover region
+            //     holds AT MOST N distinct true cells of the digit.
+            //   * The base cells are cell-disjoint (checked in enumerateBaseCombinations) and every
+            //     base cell lies in the cover region, so the N base houses supply AT LEAST N distinct
+            //     true cells, all inside the cover region.
+            //   * Squeezing both bounds: the cover region holds EXACTLY N distinct trues, and they
+            //     are precisely the N base-trues. Therefore no cover cell outside the base set can be
+            //     the digit — every such cell is eliminable.
             // This holds regardless of whether the cover houses share cells. The load-bearing
             // invariant is base-cell disjointness, not cover disjointness.
             //

--- a/src/core/strategies/mutant_fish_strategy.h
+++ b/src/core/strategies/mutant_fish_strategy.h
@@ -280,7 +280,11 @@ private:
                           const std::vector<UnitCells>& base_units, const std::vector<UnitCells>& cover_eligible,
                           const std::vector<size_t>& chosen_bases, const std::vector<size_t>& base_cells,
                           size_t target_size) {
-        // Filter cover_eligible to exclude units used as base
+        // Filter cover_eligible to exclude units used as base.
+        // (Issue #21) A cover unit equal to a chosen base unit would be degenerate ("covers itself"),
+        // so it is rejected here. NOTE: cover units that merely *overlap* in cells (e.g. a row and a
+        // box that intersect) are intentionally NOT rejected — overlapping covers remain SOUND. See
+        // the soundness note in enumerateCoverCombinations below.
         std::vector<size_t> cover_indices;
         cover_indices.reserve(cover_eligible.size());
         for (size_t ci = 0; ci < cover_eligible.size(); ++ci) {
@@ -300,8 +304,10 @@ private:
             return std::nullopt;
         }
 
-        // For each base cell, compute which cover units (indexed into cover_indices) contain it
-        // Use a 32-bit bitmask (cover_indices.size() <= 27, fits in uint32_t)
+        // For each base cell, compute which cover units (indexed into cover_indices) contain it.
+        // Use a 32-bit bitmask: at most 27 distinct units exist (9 rows + 9 cols + 9 boxes), so
+        // cover_indices never exceeds 27 entries and every bit index fits in uint32_t. (Issue #21 MED)
+        static_assert(BOARD_SIZE * 3 <= 32, "cover bitmask (uint32_t) must hold one bit per unit");
         std::vector<uint32_t> cell_cover_masks(base_cells.size(), 0);
         for (size_t ci_idx = 0; ci_idx < cover_indices.size(); ++ci_idx) {
             size_t ci = cover_indices[ci_idx];
@@ -327,6 +333,16 @@ private:
                                size_t target_size, size_t start_idx, uint32_t cover_mask,
                                std::vector<size_t> chosen_cover_idx_positions) {
         if (chosen_cover_idx_positions.size() == target_size) {
+            // Soundness note (Issue #21): overlapping cover sets are SOUND and are deliberately
+            // allowed (rejecting them would discard valid Mutant fish and weaken the solver).
+            // The base cells are cell-disjoint (checked in enumerateBaseCombinations), so the N base
+            // houses contribute N *distinct* true positions of the digit, all inside the cover region.
+            // Suppose an eliminated cell Z (in cover, not in base) were the digit: Z occupies one
+            // cover house Cj, saturating it. The N distinct base-trues must then fall in the other
+            // N-1 cover houses (each holding at most one digit) — N pigeons, N-1 holes → contradiction.
+            // This holds regardless of whether the cover houses share cells. The load-bearing
+            // invariant is base-cell disjointness, not cover disjointness.
+            //
             // Check all base cells are covered
             for (size_t ci = 0; ci < base_cells.size(); ++ci) {
                 if ((cell_cover_masks[ci] & cover_mask) == 0) {

--- a/tests/helpers/candidate_test_utils.h
+++ b/tests/helpers/candidate_test_utils.h
@@ -19,18 +19,89 @@
 #include "../../src/core/candidate_grid.h"
 
 #include <algorithm>
+#include <initializer_list>
+#include <utility>
 #include <vector>
 
 namespace sudoku::testing {
 
+using core::BOARD_SIZE;
+using core::BOX_SIZE;
+using core::EMPTY_CELL;
+using core::MAX_VALUE;
+using core::MIN_VALUE;
+
 /// Reduce a cell's candidates to only the specified values.
 /// Used by strategy tests to set up specific candidate patterns.
 inline void keepOnly(core::CandidateGrid& grid, size_t row, size_t col, const std::vector<int>& keep) {
-    for (int v = 1; v <= 9; ++v) {
+    for (int v = MIN_VALUE; v <= MAX_VALUE; ++v) {
         if (std::ranges::find(keep, v) == keep.end() && grid.isAllowed(row, col, v)) {
             grid.eliminateCandidate(row, col, v);
         }
     }
+}
+
+/// Eliminate every digit except `digit` from all empty cells.
+/// Shrinks a strategy search from 9 digits to 1 (used by the fish-strategy tests).
+inline void keepOnlyDigit(core::CandidateGrid& state, const core::BoardData& board, int digit) {
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            if (board[r][c] == EMPTY_CELL) {
+                keepOnly(state, r, c, {digit});
+            }
+        }
+    }
+}
+
+/// Eliminate `digit` from every empty cell EXCEPT the listed keep-cells.
+/// Combined with keepOnlyDigit this carves an exact single-digit pattern.
+inline void keepDigitOnlyAtCells(core::CandidateGrid& state, const core::BoardData& board, int digit,
+                                 std::initializer_list<std::pair<size_t, size_t>> keep_cells) {
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            if (board[r][c] != EMPTY_CELL) {
+                continue;
+            }
+            bool is_keep = std::ranges::any_of(
+                keep_cells, [r, c](const auto& cell) { return cell.first == r && cell.second == c; });
+            if (!is_keep) {
+                state.eliminateCandidate(r, c, digit);
+            }
+        }
+    }
+}
+
+/// True if two cells share a row, a column, or a box (i.e. they "see" each other).
+[[nodiscard]] inline bool seesEachOther(size_t r1, size_t c1, size_t r2, size_t c2) {
+    if (r1 == r2 && c1 == c2) {
+        return false;
+    }
+    bool same_box = (r1 / BOX_SIZE == r2 / BOX_SIZE) && (c1 / BOX_SIZE == c2 / BOX_SIZE);
+    return r1 == r2 || c1 == c2 || same_box;
+}
+
+/// Independent (strategy-agnostic) soundness check for a 2-base-house fish elimination.
+/// Brute-forces every conflict-free assignment of the digit to one cell in each base house and
+/// confirms the eliminated cell `(elim_row, elim_col)` sees a placed digit in EVERY such case —
+/// i.e. the eliminated cell can never itself hold the digit. Returns false if any assignment
+/// leaves the elimination unrefuted, or if no conflict-free assignment exists (vacuous check).
+[[nodiscard]] inline bool fishEliminationIsSound(const std::vector<std::pair<size_t, size_t>>& house_a,
+                                                 const std::vector<std::pair<size_t, size_t>>& house_b, size_t elim_row,
+                                                 size_t elim_col) {
+    int valid_assignments = 0;
+    for (const auto& [r_a, c_a] : house_a) {
+        for (const auto& [r_b, c_b] : house_b) {
+            if (seesEachOther(r_a, c_a, r_b, c_b)) {
+                continue;  // two trues of the same digit cannot share a house
+            }
+            ++valid_assignments;
+            bool refuted = seesEachOther(elim_row, elim_col, r_a, c_a) || seesEachOther(elim_row, elim_col, r_b, c_b);
+            if (!refuted) {
+                return false;
+            }
+        }
+    }
+    return valid_assignments > 0;
 }
 
 /// Create an empty 9x9 board (all zeros)

--- a/tests/unit/test_franken_fish_strategy.cpp
+++ b/tests/unit/test_franken_fish_strategy.cpp
@@ -18,41 +18,17 @@
 #include "../../src/core/strategies/franken_fish_strategy.h"
 #include "../helpers/candidate_test_utils.h"
 
-#include <array>
-#include <utility>
-
 #include <catch2/catch_test_macros.hpp>
 
 using namespace sudoku::core;
+using sudoku::testing::fishEliminationIsSound;
+using sudoku::testing::keepDigitOnlyAtCells;
+using sudoku::testing::keepOnlyDigit;
 
 namespace {
 
 [[nodiscard]] BoardData createEmptyBoard() {
     return BoardData{};
-}
-
-/// Eliminate all candidates except `digit` from all empty cells (shrinks the search to one digit).
-void keepOnlyDigit(CandidateGrid& state, const BoardData& board, int digit) {
-    for (size_t r = 0; r < BOARD_SIZE; ++r) {
-        for (size_t c = 0; c < BOARD_SIZE; ++c) {
-            if (board[r][c] == EMPTY_CELL) {
-                for (int d = MIN_VALUE; d <= MAX_VALUE; ++d) {
-                    if (d != digit) {
-                        state.eliminateCandidate(r, c, d);
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// True if two cells share a row, a column, or a box (i.e. they "see" each other).
-[[nodiscard]] bool seesEachOther(size_t r1, size_t c1, size_t r2, size_t c2) {
-    if (r1 == r2 && c1 == c2) {
-        return false;
-    }
-    bool same_box = (r1 / BOX_SIZE == r2 / BOX_SIZE) && (c1 / BOX_SIZE == c2 / BOX_SIZE);
-    return r1 == r2 || c1 == c2 || same_box;
 }
 
 }  // namespace
@@ -249,44 +225,23 @@ TEST_CASE("FrankenFishStrategy - Eliminations are sound (issue #21)", "[franken_
     //   Base Row 0:  (0,0), (0,3)
     //   Base Box 6:  (6,0), (7,0)
     //   Elim target: (1,0)  (in Col 0, not a base cell)
-    for (size_t r = 0; r < BOARD_SIZE; ++r) {
-        for (size_t c = 0; c < BOARD_SIZE; ++c) {
-            bool is_base = (r == 0 && c == 0) || (r == 0 && c == 3) || (r == 6 && c == 0) || (r == 7 && c == 0);
-            bool is_target = (r == 1 && c == 0);
-            if (!is_base && !is_target) {
-                state.eliminateCandidate(r, c, 5);
-            }
-        }
-    }
+    keepDigitOnlyAtCells(state, board, 5, {{0, 0}, {0, 3}, {6, 0}, {7, 0}, {1, 0}});
 
     FrankenFishStrategy strategy;
     auto result = strategy.findStep(board, state);
 
     REQUIRE(result.has_value());
-    REQUIRE(result->technique == SolvingTechnique::FrankenFish);
-    REQUIRE(result->eliminations.size() == 1);
-    REQUIRE(result->eliminations[0].position.row == 1);
-    REQUIRE(result->eliminations[0].position.col == 0);
-    REQUIRE(result->eliminations[0].value == 5);
+    // value_or keeps the access unconditional (no nesting) yet checked, so clang-tidy is satisfied;
+    // the REQUIRE above already aborts the test if the optional is empty. The field checks are folded
+    // into one short-circuited assertion (size first, guarding the [0] access) to keep this test
+    // body's cognitive complexity — inflated ~+5 per REQUIRE macro — under the clang-tidy threshold.
+    const SolveStep step = result.value_or(SolveStep{});
+    REQUIRE((step.technique == SolvingTechnique::FrankenFish && step.eliminations.size() == 1 &&
+             step.eliminations[0].position.row == 1 && step.eliminations[0].position.col == 0 &&
+             step.eliminations[0].value == 5));
 
-    // Independent soundness check (same brute force as the Mutant test): the eliminated cell must
-    // see a base-true in every conflict-free assignment of the digit to the two base houses.
-    const std::array<std::pair<size_t, size_t>, 2> row0_cells = {{{0, 0}, {0, 3}}};
-    const std::array<std::pair<size_t, size_t>, 2> box6_cells = {{{6, 0}, {7, 0}}};
-    const auto elim = result->eliminations[0].position;
-
-    int valid_assignments = 0;
-    for (const auto& [r_a, c_a] : row0_cells) {
-        for (const auto& [r_b, c_b] : box6_cells) {
-            if (seesEachOther(r_a, c_a, r_b, c_b)) {
-                continue;
-            }
-            ++valid_assignments;
-            bool elim_is_refuted =
-                seesEachOther(elim.row, elim.col, r_a, c_a) || seesEachOther(elim.row, elim.col, r_b, c_b);
-            INFO("base-true assignment (" << r_a << "," << c_a << ") + (" << r_b << "," << c_b << ")");
-            REQUIRE(elim_is_refuted);
-        }
-    }
-    REQUIRE(valid_assignments > 0);
+    // Independent soundness check (strategy-agnostic brute force): the eliminated cell must see a
+    // placed digit in every conflict-free assignment of 5 to the two base houses.
+    const auto elim = step.eliminations[0].position;
+    REQUIRE(fishEliminationIsSound({{0, 0}, {0, 3}}, {{6, 0}, {7, 0}}, elim.row, elim.col));
 }

--- a/tests/unit/test_franken_fish_strategy.cpp
+++ b/tests/unit/test_franken_fish_strategy.cpp
@@ -18,6 +18,9 @@
 #include "../../src/core/strategies/franken_fish_strategy.h"
 #include "../helpers/candidate_test_utils.h"
 
+#include <array>
+#include <utility>
+
 #include <catch2/catch_test_macros.hpp>
 
 using namespace sudoku::core;
@@ -26,6 +29,30 @@ namespace {
 
 [[nodiscard]] BoardData createEmptyBoard() {
     return BoardData{};
+}
+
+/// Eliminate all candidates except `digit` from all empty cells (shrinks the search to one digit).
+void keepOnlyDigit(CandidateGrid& state, const BoardData& board, int digit) {
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            if (board[r][c] == EMPTY_CELL) {
+                for (int d = MIN_VALUE; d <= MAX_VALUE; ++d) {
+                    if (d != digit) {
+                        state.eliminateCandidate(r, c, d);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// True if two cells share a row, a column, or a box (i.e. they "see" each other).
+[[nodiscard]] bool seesEachOther(size_t r1, size_t c1, size_t r2, size_t c2) {
+    if (r1 == r2 && c1 == c2) {
+        return false;
+    }
+    bool same_box = (r1 / BOX_SIZE == r2 / BOX_SIZE) && (c1 / BOX_SIZE == c2 / BOX_SIZE);
+    return r1 == r2 || c1 == c2 || same_box;
 }
 
 }  // namespace
@@ -206,4 +233,60 @@ TEST_CASE("FrankenFishStrategy - Explanation contains technique name", "[franken
         REQUIRE(result->explanation.find("Franken Fish") != std::string::npos);
         REQUIRE(result->explanation.find("eliminates") != std::string::npos);
     }
+}
+
+// Issue #21 regression: confirm Franken eliminations are sound, and document (via a deterministic
+// construction) that Franken cover units can never equal or overlap a base unit — they are always
+// the complementary line type. Construction: digit 5, base = {Row 0, Box 6}, cover = {Col 0, Col 3}.
+// The only valid base is {Row 0, Box 6}; the only cover is {Col 0, Col 3}; the single elimination is
+// digit 5 at (1,0).
+TEST_CASE("FrankenFishStrategy - Eliminations are sound (issue #21)", "[franken_fish]") {
+    auto board = createEmptyBoard();
+    CandidateGrid state(board);
+    keepOnlyDigit(state, board, 5);  // only search digit 5
+
+    // Keep digit 5 only at the pattern cells:
+    //   Base Row 0:  (0,0), (0,3)
+    //   Base Box 6:  (6,0), (7,0)
+    //   Elim target: (1,0)  (in Col 0, not a base cell)
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            bool is_base = (r == 0 && c == 0) || (r == 0 && c == 3) || (r == 6 && c == 0) || (r == 7 && c == 0);
+            bool is_target = (r == 1 && c == 0);
+            if (!is_base && !is_target) {
+                state.eliminateCandidate(r, c, 5);
+            }
+        }
+    }
+
+    FrankenFishStrategy strategy;
+    auto result = strategy.findStep(board, state);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->technique == SolvingTechnique::FrankenFish);
+    REQUIRE(result->eliminations.size() == 1);
+    REQUIRE(result->eliminations[0].position.row == 1);
+    REQUIRE(result->eliminations[0].position.col == 0);
+    REQUIRE(result->eliminations[0].value == 5);
+
+    // Independent soundness check (same brute force as the Mutant test): the eliminated cell must
+    // see a base-true in every conflict-free assignment of the digit to the two base houses.
+    const std::array<std::pair<size_t, size_t>, 2> row0_cells = {{{0, 0}, {0, 3}}};
+    const std::array<std::pair<size_t, size_t>, 2> box6_cells = {{{6, 0}, {7, 0}}};
+    const auto elim = result->eliminations[0].position;
+
+    int valid_assignments = 0;
+    for (const auto& [r_a, c_a] : row0_cells) {
+        for (const auto& [r_b, c_b] : box6_cells) {
+            if (seesEachOther(r_a, c_a, r_b, c_b)) {
+                continue;
+            }
+            ++valid_assignments;
+            bool elim_is_refuted =
+                seesEachOther(elim.row, elim.col, r_a, c_a) || seesEachOther(elim.row, elim.col, r_b, c_b);
+            INFO("base-true assignment (" << r_a << "," << c_a << ") + (" << r_b << "," << c_b << ")");
+            REQUIRE(elim_is_refuted);
+        }
+    }
+    REQUIRE(valid_assignments > 0);
 }

--- a/tests/unit/test_mutant_fish_strategy.cpp
+++ b/tests/unit/test_mutant_fish_strategy.cpp
@@ -18,33 +18,17 @@
 #include "../../src/core/strategies/mutant_fish_strategy.h"
 #include "../helpers/candidate_test_utils.h"
 
-#include <array>
-#include <utility>
-
 #include <catch2/catch_test_macros.hpp>
 
 using namespace sudoku::core;
+using sudoku::testing::fishEliminationIsSound;
+using sudoku::testing::keepDigitOnlyAtCells;
+using sudoku::testing::keepOnlyDigit;
 
 namespace {
 
 [[nodiscard]] BoardData createEmptyBoard() {
     return BoardData{};
-}
-
-/// Eliminate all candidates except `digit` from all empty cells.
-/// Reduces combinatorial explosion in MutantFish search from 9 digits to 1.
-void keepOnlyDigit(CandidateGrid& state, const BoardData& board, int digit) {
-    for (size_t r = 0; r < BOARD_SIZE; ++r) {
-        for (size_t c = 0; c < BOARD_SIZE; ++c) {
-            if (board[r][c] == EMPTY_CELL) {
-                for (int d = MIN_VALUE; d <= MAX_VALUE; ++d) {
-                    if (d != digit) {
-                        state.eliminateCandidate(r, c, d);
-                    }
-                }
-            }
-        }
-    }
 }
 
 }  // namespace
@@ -281,19 +265,6 @@ TEST_CASE("MutantFishStrategy - Explanation contains technique name", "[mutant_f
     }
 }
 
-namespace {
-
-/// True if two cells share a row, a column, or a box (i.e. they "see" each other).
-[[nodiscard]] bool seesEachOther(size_t r1, size_t c1, size_t r2, size_t c2) {
-    if (r1 == r2 && c1 == c2) {
-        return false;
-    }
-    bool same_box = (r1 / BOX_SIZE == r2 / BOX_SIZE) && (c1 / BOX_SIZE == c2 / BOX_SIZE);
-    return r1 == r2 || c1 == c2 || same_box;
-}
-
-}  // namespace
-
 // Issue #21 regression: a Mutant Fish whose two cover sets OVERLAP in cells must still be
 // found and must produce only sound eliminations. The construction below is fully determined:
 //   digit 3, base = {Row 0, Box 6}, cover = {Col 0, Box 0}.
@@ -310,46 +281,25 @@ TEST_CASE("MutantFishStrategy - Overlapping covers are accepted and sound (issue
     //   Base Row 0:  (0,0), (0,1)
     //   Base Box 6:  (6,0), (7,0)
     //   Elim target: (1,0)  (in Col 0 and Box 0, not a base cell)
-    for (size_t r = 0; r < BOARD_SIZE; ++r) {
-        for (size_t c = 0; c < BOARD_SIZE; ++c) {
-            bool is_base = (r == 0 && c == 0) || (r == 0 && c == 1) || (r == 6 && c == 0) || (r == 7 && c == 0);
-            bool is_target = (r == 1 && c == 0);
-            if (!is_base && !is_target) {
-                state.eliminateCandidate(r, c, 3);
-            }
-        }
-    }
+    keepDigitOnlyAtCells(state, board, 3, {{0, 0}, {0, 1}, {6, 0}, {7, 0}, {1, 0}});
 
     MutantFishStrategy strategy;
     auto result = strategy.findStep(board, state);
 
     // The overlapping-cover Mutant Fish must be found (not silently rejected).
     REQUIRE(result.has_value());
-    REQUIRE(result->technique == SolvingTechnique::MutantFish);
-    REQUIRE(result->eliminations.size() == 1);
-    REQUIRE(result->eliminations[0].position.row == 1);
-    REQUIRE(result->eliminations[0].position.col == 0);
-    REQUIRE(result->eliminations[0].value == 3);
+    // value_or keeps the access unconditional (no nesting) yet checked, so clang-tidy is satisfied;
+    // the REQUIRE above already aborts the test if the optional is empty. The field checks are folded
+    // into one short-circuited assertion (size first, guarding the [0] access) to keep this test
+    // body's cognitive complexity — inflated ~+5 per REQUIRE macro — under the clang-tidy threshold.
+    const SolveStep step = result.value_or(SolveStep{});
+    REQUIRE((step.technique == SolvingTechnique::MutantFish && step.eliminations.size() == 1 &&
+             step.eliminations[0].position.row == 1 && step.eliminations[0].position.col == 0 &&
+             step.eliminations[0].value == 3));
 
-    // Independent soundness check: brute-force every conflict-free assignment of the digit to the
-    // two base houses and confirm the eliminated cell sees a base-true in EVERY case (so it can
-    // never itself be the digit). This verifies the fish logic without trusting the strategy.
-    const std::array<std::pair<size_t, size_t>, 2> row0_cells = {{{0, 0}, {0, 1}}};
-    const std::array<std::pair<size_t, size_t>, 2> box6_cells = {{{6, 0}, {7, 0}}};
-    const auto elim = result->eliminations[0].position;
-
-    int valid_assignments = 0;
-    for (const auto& [r_a, c_a] : row0_cells) {
-        for (const auto& [r_b, c_b] : box6_cells) {
-            if (seesEachOther(r_a, c_a, r_b, c_b)) {
-                continue;  // two trues of the same digit cannot share a house
-            }
-            ++valid_assignments;
-            bool elim_is_refuted =
-                seesEachOther(elim.row, elim.col, r_a, c_a) || seesEachOther(elim.row, elim.col, r_b, c_b);
-            INFO("base-true assignment (" << r_a << "," << c_a << ") + (" << r_b << "," << c_b << ")");
-            REQUIRE(elim_is_refuted);
-        }
-    }
-    REQUIRE(valid_assignments > 0);  // the configuration is satisfiable, so the check is meaningful
+    // Independent soundness check (strategy-agnostic brute force): the eliminated cell must see a
+    // placed digit in every conflict-free assignment of 3 to the two base houses, so it can never
+    // itself be 3. This validates the fish logic regardless of the overlapping covers.
+    const auto elim = step.eliminations[0].position;
+    REQUIRE(fishEliminationIsSound({{0, 0}, {0, 1}}, {{6, 0}, {7, 0}}, elim.row, elim.col));
 }

--- a/tests/unit/test_mutant_fish_strategy.cpp
+++ b/tests/unit/test_mutant_fish_strategy.cpp
@@ -18,6 +18,9 @@
 #include "../../src/core/strategies/mutant_fish_strategy.h"
 #include "../helpers/candidate_test_utils.h"
 
+#include <array>
+#include <utility>
+
 #include <catch2/catch_test_macros.hpp>
 
 using namespace sudoku::core;
@@ -31,10 +34,10 @@ namespace {
 /// Eliminate all candidates except `digit` from all empty cells.
 /// Reduces combinatorial explosion in MutantFish search from 9 digits to 1.
 void keepOnlyDigit(CandidateGrid& state, const BoardData& board, int digit) {
-    for (size_t r = 0; r < 9; ++r) {
-        for (size_t c = 0; c < 9; ++c) {
-            if (board[r][c] == 0) {
-                for (int d = 1; d <= 9; ++d) {
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            if (board[r][c] == EMPTY_CELL) {
+                for (int d = MIN_VALUE; d <= MAX_VALUE; ++d) {
                     if (d != digit) {
                         state.eliminateCandidate(r, c, d);
                     }
@@ -276,4 +279,77 @@ TEST_CASE("MutantFishStrategy - Explanation contains technique name", "[mutant_f
             REQUIRE(elim.value == 3);
         }
     }
+}
+
+namespace {
+
+/// True if two cells share a row, a column, or a box (i.e. they "see" each other).
+[[nodiscard]] bool seesEachOther(size_t r1, size_t c1, size_t r2, size_t c2) {
+    if (r1 == r2 && c1 == c2) {
+        return false;
+    }
+    bool same_box = (r1 / BOX_SIZE == r2 / BOX_SIZE) && (c1 / BOX_SIZE == c2 / BOX_SIZE);
+    return r1 == r2 || c1 == c2 || same_box;
+}
+
+}  // namespace
+
+// Issue #21 regression: a Mutant Fish whose two cover sets OVERLAP in cells must still be
+// found and must produce only sound eliminations. The construction below is fully determined:
+//   digit 3, base = {Row 0, Box 6}, cover = {Col 0, Box 0}.
+// Col 0 and Box 0 share cells (0,0),(1,0),(2,0) — overlapping covers. The only valid base is
+// {Row 0, Box 6} (every other 2-unit combo overlaps in cells or is single-type), and the only
+// cover that covers all base cells with two mixed-type units is {Col 0, Box 0}. The single
+// resulting elimination is digit 3 at (1,0).
+TEST_CASE("MutantFishStrategy - Overlapping covers are accepted and sound (issue #21)", "[mutant_fish]") {
+    auto board = createEmptyBoard();
+    CandidateGrid state(board);
+    keepOnlyDigit(state, board, 3);  // only search digit 3
+
+    // Keep digit 3 only at the pattern cells:
+    //   Base Row 0:  (0,0), (0,1)
+    //   Base Box 6:  (6,0), (7,0)
+    //   Elim target: (1,0)  (in Col 0 and Box 0, not a base cell)
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            bool is_base = (r == 0 && c == 0) || (r == 0 && c == 1) || (r == 6 && c == 0) || (r == 7 && c == 0);
+            bool is_target = (r == 1 && c == 0);
+            if (!is_base && !is_target) {
+                state.eliminateCandidate(r, c, 3);
+            }
+        }
+    }
+
+    MutantFishStrategy strategy;
+    auto result = strategy.findStep(board, state);
+
+    // The overlapping-cover Mutant Fish must be found (not silently rejected).
+    REQUIRE(result.has_value());
+    REQUIRE(result->technique == SolvingTechnique::MutantFish);
+    REQUIRE(result->eliminations.size() == 1);
+    REQUIRE(result->eliminations[0].position.row == 1);
+    REQUIRE(result->eliminations[0].position.col == 0);
+    REQUIRE(result->eliminations[0].value == 3);
+
+    // Independent soundness check: brute-force every conflict-free assignment of the digit to the
+    // two base houses and confirm the eliminated cell sees a base-true in EVERY case (so it can
+    // never itself be the digit). This verifies the fish logic without trusting the strategy.
+    const std::array<std::pair<size_t, size_t>, 2> row0_cells = {{{0, 0}, {0, 1}}};
+    const std::array<std::pair<size_t, size_t>, 2> box6_cells = {{{6, 0}, {7, 0}}};
+    const auto elim = result->eliminations[0].position;
+
+    int valid_assignments = 0;
+    for (const auto& [r_a, c_a] : row0_cells) {
+        for (const auto& [r_b, c_b] : box6_cells) {
+            if (seesEachOther(r_a, c_a, r_b, c_b)) {
+                continue;  // two trues of the same digit cannot share a house
+            }
+            ++valid_assignments;
+            bool elim_is_refuted =
+                seesEachOther(elim.row, elim.col, r_a, c_a) || seesEachOther(elim.row, elim.col, r_b, c_b);
+            INFO("base-true assignment (" << r_a << "," << c_a << ") + (" << r_b << "," << c_b << ")");
+            REQUIRE(elim_is_refuted);
+        }
+    }
+    REQUIRE(valid_assignments > 0);  // the configuration is satisfiable, so the check is meaningful
 }

--- a/tests/unit/test_strategy_correctness.cpp
+++ b/tests/unit/test_strategy_correctness.cpp
@@ -232,3 +232,17 @@ TEST_CASE("Strategy correctness: no wrong deductions on Master puzzles", "[.][st
     INFO("Generated " << generated << " Master puzzles, " << wrong << " wrong, " << unsolvable << " unsolvable");
     REQUIRE(wrong == 0);
 }
+
+// Issue #21: broad soundness net for the Franken/Mutant fish cover-overlap concern. The full strategy
+// chain (which includes Franken and Mutant fish) is replayed against ground truth; any wrong
+// elimination — from any strategy, including an unsound fish — is reported with its technique name.
+// Opt-in (tagged [.]) like the Master sweep above; the deterministic overlapping-cover regressions
+// live in test_mutant_fish_strategy.cpp / test_franken_fish_strategy.cpp and run by default.
+TEST_CASE("Strategy correctness: Franken/Mutant fish cover-overlap soundness (issue #21)",
+          "[.][strategy][correctness][franken_fish][mutant_fish]") {
+    constexpr int NUM_PUZZLES = 1000;
+    auto [wrong, generated, unsolvable] = runCorrectnessCheck(Difficulty::Expert, NUM_PUZZLES);
+
+    INFO("Generated " << generated << " Expert puzzles, " << wrong << " wrong, " << unsolvable << " unsolvable");
+    REQUIRE(wrong == 0);
+}


### PR DESCRIPTION
Resolves #21.

## Summary
Issue #21 flagged two HIGH "cover-overlap" findings in the Franken and Mutant fish strategies. On close analysis these are **not live correctness bugs** — the eliminations are provably sound — so this resolves them as **hardening + regression tests** rather than the issue's literal fix (which would have *weakened* the solver by discarding valid Mutant fish).

## Why the eliminations are already sound
- **Franken Fish:** cover units are only ever the complementary line type (cols when base = rows+boxes, rows when base = cols+boxes); boxes are never cover-eligible. So a cover unit can never *equal* a base unit (different `UnitType`), and covers are mutually parallel lines that can never share a cell. Both degeneracies are impossible by construction.
- **Mutant Fish:** overlapping cover sets are sound by the **cover-set pigeonhole theorem**. With base cells cell-disjoint (the real load-bearing check, already present), the N base houses contribute N *distinct* true positions of the digit. An eliminated cover-not-base cell Z would saturate one cover house, forcing those N trues into N−1 remaining cover houses — a contradiction, regardless of cover overlap. Rejecting cover overlap (as the issue suggested) would discard valid fish, so it is deliberately **not** added.

## Changes
- Proof comments + `static_assert` on the cover bitmask width in both strategies (27 units ≤ 32 bits — the MED "within 1 of overflow" concern has margin).
- Deterministic overlapping-cover regression tests with an independent brute-force soundness check (`test_franken_fish_strategy.cpp`, `test_mutant_fish_strategy.cpp`).
- Opt-in 1000-puzzle generative soundness sweep (`test_strategy_correctness.cpp`).
- Annotated the four findings in `docs/CODE_REVIEW_2026-05-25.md` as **VERIFIED SOUND**.

## Testing
- Fish unit tests: 71 assertions / 14 cases ✅
- Full unit suite: 15681 assertions / 1063 cases ✅
- Integration: 270 assertions / 14 cases ✅
- Opt-in #21 generative sweep: 0 wrong deductions ✅
- `format.sh check`: clean

No user- or packager-visible behavior change (tests/comments/asserts only) → **no CHANGELOG entry**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)