### PR TITLE
refactor(solver): split region_type into pattern_axis + elimination_axis (#39)

### DIFF
--- a/src/core/localized_explanations.h
+++ b/src/core/localized_explanations.h
@@ -198,11 +198,11 @@ namespace sudoku::core {
                 localizedRegion(data.region_type, data.region_index));
         }
         case SolvingTechnique::XWing: {
-            if (data.values.empty() || data.region_type == RegionType::None) {
+            if (data.values.empty() || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
-            // Row-based: region_type=Row, Col-based: region_type=Col
-            if (data.region_type == RegionType::Row) {
+            // Row-based: pattern_axis=Row, Col-based: pattern_axis=Col (gh#39)
+            if (data.pattern_axis == RegionType::Row) {
                 // Rows {1} and {2}, Columns {3} and {4}
                 // Positions: [r1c1, r1c2, r2c1, r2c2]
                 if (data.positions.size() < 4) {
@@ -238,10 +238,10 @@ namespace sudoku::core {
         }
         case SolvingTechnique::Swordfish: {
             // values = {candidate, r1, r2, r3, c1, c2, c3} (1-indexed from strategy)
-            if (data.values.size() < 7 || data.region_type == RegionType::None) {
+            if (data.values.size() < 7 || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 // Row-based: rows then cols
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku",
@@ -376,7 +376,7 @@ namespace sudoku::core {
                 data.values[0], localizedPosition(data.positions[0]));
         }
         case SolvingTechnique::FinnedXWing: {
-            if (data.values.empty() || data.region_type == RegionType::None) {
+            if (data.values.empty() || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
             // values = {candidate, row/col1, row/col2, col/row1, col/row2}, positions includes fin
@@ -384,7 +384,7 @@ namespace sudoku::core {
                 return step.explanation;
             }
             auto fin_pos = localizedPosition(data.positions.back());
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku",
                                            "Finned X-Wing on value {0} in Rows {1} and {2}, Columns {3} and {4} with "
@@ -418,10 +418,10 @@ namespace sudoku::core {
         }
         case SolvingTechnique::Jellyfish: {
             // values = {candidate, r1, r2, r3, r4, c1, c2, c3, c4} (1-indexed)
-            if (data.values.size() < 9 || data.region_type == RegionType::None) {
+            if (data.values.size() < 9 || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku",
                                            "Jellyfish on value {0} in Rows {1}, {2}, {3}, {4} and Columns {5}, {6}, "
@@ -438,11 +438,11 @@ namespace sudoku::core {
         }
         case SolvingTechnique::FinnedSwordfish: {
             // values = {candidate, row/col1, row/col2, row/col3}, positions includes fin at back
-            if (data.positions.empty() || data.values.size() < 4 || data.region_type == RegionType::None) {
+            if (data.positions.empty() || data.values.size() < 4 || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
             auto fin_pos = localizedPosition(data.positions.back());
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku", "Finned Swordfish on value {0} in Rows {1}, {2}, {3} with "
                                                      "fin at {4} — eliminates {0} from cells in fin's box")),
@@ -478,11 +478,11 @@ namespace sudoku::core {
         }
         case SolvingTechnique::FinnedJellyfish: {
             // values = {candidate, row/col1..4}, positions includes fin at back
-            if (data.positions.empty() || data.values.size() < 5 || data.region_type == RegionType::None) {
+            if (data.positions.empty() || data.values.size() < 5 || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
             auto fin_pos = localizedPosition(data.positions.back());
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku", "Finned Jellyfish on value {0} in Rows {1}, {2}, {3}, {4} "
                                                      "with fin at {5} — eliminates {0} from cells in fin's box")),
@@ -697,7 +697,7 @@ namespace sudoku::core {
                 data.values[0], data.values.size() >= 2 ? std::to_string(data.values[1]) : "");
         }
         case SolvingTechnique::SashimiXWing: {
-            if (data.values.empty() || data.positions.empty() || data.region_type == RegionType::None) {
+            if (data.values.empty() || data.positions.empty() || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
             // values = {candidate, row/col1, row/col2}, fin is last position
@@ -705,7 +705,7 @@ namespace sudoku::core {
                 return step.explanation;
             }
             auto fin_pos = localizedPosition(data.positions.back());
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku",
                                            "Sashimi X-Wing on value {0} in Rows {1} and {2}, Columns {3} and {4} with "
@@ -719,11 +719,11 @@ namespace sudoku::core {
                 data.values[0], data.values[1], data.values[2], fin_pos);
         }
         case SolvingTechnique::SashimiSwordfish: {
-            if (data.positions.empty() || data.values.size() < 4 || data.region_type == RegionType::None) {
+            if (data.positions.empty() || data.values.size() < 4 || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
             auto fin_pos = localizedPosition(data.positions.back());
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku", "Sashimi Swordfish on value {0} in Rows {1}, {2}, {3} with "
                                                      "fin at {4} — eliminates {0} from cells in fin's box")),
@@ -735,11 +735,11 @@ namespace sudoku::core {
                 data.values[0], data.values[1], data.values[2], data.values[3], fin_pos);
         }
         case SolvingTechnique::SashimiJellyfish: {
-            if (data.positions.empty() || data.values.size() < 5 || data.region_type == RegionType::None) {
+            if (data.positions.empty() || data.values.size() < 5 || data.pattern_axis == RegionType::None) {
                 return step.explanation;
             }
             auto fin_pos = localizedPosition(data.positions.back());
-            if (data.region_type == RegionType::Row) {
+            if (data.pattern_axis == RegionType::Row) {
                 return fmt::format(
                     fmt::runtime(core::loc("Sudoku", "Sashimi Jellyfish on value {0} in Rows {1}, {2}, {3}, {4} "
                                                      "with fin at {5} — eliminates {0} from cells in fin's box")),

--- a/src/core/solve_step.h
+++ b/src/core/solve_step.h
@@ -81,11 +81,23 @@ struct ExplanationData {
     std::vector<Position>
         positions{};            // NOLINT(readability-redundant-member-init) - Suppresses -Wmissing-field-initializers
     std::vector<int> values{};  // NOLINT(readability-redundant-member-init) - Suppresses -Wmissing-field-initializers
-    RegionType region_type{RegionType::None};            ///< Region involved (Row/Col/Box)
-    size_t region_index{0};                              ///< Region index (0-indexed)
+    RegionType region_type{RegionType::None};  ///< A single *named* region (paired with region_index), used by
+                                               ///< non-fish techniques (Naked/Hidden Pair/Triple/Quad, PointingPair,
+                                               ///< BoxLineReduction, EmptyRectangle) for "Row 3"/"Box 7" rendering.
+                                               ///< NOT a fish base axis — see pattern_axis. (gh#39)
+    size_t region_index{0};                    ///< Region index (0-indexed); only meaningful alongside region_type.
     RegionType secondary_region_type{RegionType::None};  ///< For techniques spanning two regions
     size_t secondary_region_index{0};                    ///< Secondary region index
-    int technique_subtype{-1};                           ///< Technique-specific variant (UR type, coloring mode, etc.)
+    RegionType pattern_axis{
+        RegionType::None};  ///< Base-axis orientation of a fish pattern (Row when bases are rows,
+                            ///< Col when bases are columns). Drives fish localized-template
+                            ///< selection; replaces the former overloaded use of region_type. (gh#39)
+    RegionType elimination_axis{RegionType::None};  ///< Axis/region where this technique's eliminations land: the
+                                                    ///< perpendicular line for basic fish, Box for finned/sashimi,
+                                                    ///< None when not a single axis (e.g. Kraken chain eliminations).
+    // TODO(gh#39): elimination_axis is the load-bearing hook for a future fish-line / elimination-region highlight
+    // in src/view/; owner = maintainer until that feature is scheduled. No consumer reads it yet.
+    int technique_subtype{-1};  ///< Technique-specific variant (UR type, coloring mode, etc.)
     std::vector<CellRole>
         position_roles{};  // NOLINT(readability-redundant-member-init) - Suppresses -Wmissing-field-initializers
 

--- a/src/core/strategies/finned_jellyfish_strategy.h
+++ b/src/core/strategies/finned_jellyfish_strategy.h
@@ -137,7 +137,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(r1 + 1), static_cast<int>(r2 + 1),
                                                              static_cast<int>(r3 + 1), static_cast<int>(r4 + 1)},
-                                                  .region_type = RegionType::Row,
+                                                  .pattern_axis = RegionType::Row,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;
@@ -222,7 +223,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(c1 + 1), static_cast<int>(c2 + 1),
                                                              static_cast<int>(c3 + 1), static_cast<int>(c4 + 1)},
-                                                  .region_type = RegionType::Col,
+                                                  .pattern_axis = RegionType::Col,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;

--- a/src/core/strategies/finned_swordfish_strategy.h
+++ b/src/core/strategies/finned_swordfish_strategy.h
@@ -132,7 +132,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(r1 + 1), static_cast<int>(r2 + 1),
                                                              static_cast<int>(r3 + 1)},
-                                                  .region_type = RegionType::Row,
+                                                  .pattern_axis = RegionType::Row,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;
@@ -211,7 +212,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(c1 + 1), static_cast<int>(c2 + 1),
                                                              static_cast<int>(c3 + 1)},
-                                                  .region_type = RegionType::Col,
+                                                  .pattern_axis = RegionType::Col,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;

--- a/src/core/strategies/finned_x_wing_strategy.h
+++ b/src/core/strategies/finned_x_wing_strategy.h
@@ -154,7 +154,8 @@ private:
                                                Position{.row = row2, .col = base_col2}, fin_pos},
                                  .values = {value, static_cast<int>(row1 + 1), static_cast<int>(row2 + 1),
                                             static_cast<int>(base_col1 + 1), static_cast<int>(base_col2 + 1)},
-                                 .region_type = RegionType::Row,
+                                 .pattern_axis = RegionType::Row,
+                                 .elimination_axis = RegionType::Box,
                                  .position_roles = {CellRole::Pattern, CellRole::Pattern, CellRole::Pattern,
                                                     CellRole::Pattern, CellRole::Fin}}};
     }
@@ -246,7 +247,8 @@ private:
                                                Position{.row = base_row2, .col = col2}, fin_pos},
                                  .values = {value, static_cast<int>(col1 + 1), static_cast<int>(col2 + 1),
                                             static_cast<int>(base_row1 + 1), static_cast<int>(base_row2 + 1)},
-                                 .region_type = RegionType::Col,
+                                 .pattern_axis = RegionType::Col,
+                                 .elimination_axis = RegionType::Box,
                                  .position_roles = {CellRole::Pattern, CellRole::Pattern, CellRole::Pattern,
                                                     CellRole::Pattern, CellRole::Fin}}};
     }

--- a/src/core/strategies/jellyfish_strategy.h
+++ b/src/core/strategies/jellyfish_strategy.h
@@ -132,8 +132,8 @@ private:
                                                                     static_cast<int>(union_cols[1] + 1),
                                                                     static_cast<int>(union_cols[2] + 1),
                                                                     static_cast<int>(union_cols[3] + 1)},
-                                                         .region_type = RegionType::Row,
-                                                         .region_index = r1}};
+                                                         .pattern_axis = RegionType::Row,
+                                                         .elimination_axis = RegionType::Col}};
                             }
                         }
                     }
@@ -217,8 +217,8 @@ private:
                                                                     static_cast<int>(union_rows[1] + 1),
                                                                     static_cast<int>(union_rows[2] + 1),
                                                                     static_cast<int>(union_rows[3] + 1)},
-                                                         .region_type = RegionType::Col,
-                                                         .region_index = c1}};
+                                                         .pattern_axis = RegionType::Col,
+                                                         .elimination_axis = RegionType::Row}};
                             }
                         }
                     }

--- a/src/core/strategies/kraken_fish_strategy.h
+++ b/src/core/strategies/kraken_fish_strategy.h
@@ -257,23 +257,24 @@ private:
             explain_values.push_back(static_cast<int>(bp + 1));
         }
 
-        return SolveStep{.type = SolveStepType::Elimination,
-                         .technique = SolvingTechnique::KrakenFish,
-                         .position = outcome.eliminations[0].position,
-                         .value = 0,
-                         .eliminations = std::move(outcome.eliminations),
-                         .explanation = explanation,
-                         .rating = rating,
-                         .explanation_data = {.positions = positions,
-                                              .values = std::move(explain_values),
-                                              // Convention across the fish family ([localized_explanations.h:204]
-                                              // for XWing, mirrored by Swordfish/Jellyfish/Finned*/Sashimi*):
-                                              // `region_type` encodes the *base-axis orientation* of the pattern
-                                              // (Row when bases are rows, Col when bases are columns) — it is not
-                                              // the axis where eliminations land. See gh#39 for the open question
-                                              // of unifying this semantic across all techniques.
-                                              .region_type = by_row ? RegionType::Row : RegionType::Col,
-                                              .position_roles = std::move(roles)}};
+        return SolveStep{
+            .type = SolveStepType::Elimination,
+            .technique = SolvingTechnique::KrakenFish,
+            .position = outcome.eliminations[0].position,
+            .value = 0,
+            .eliminations = std::move(outcome.eliminations),
+            .explanation = explanation,
+            .rating = rating,
+            .explanation_data = {.positions = positions,
+                                 .values = std::move(explain_values),
+                                 // Convention across the fish family ([localized_explanations.h:204]
+                                 // for XWing, mirrored by Swordfish/Jellyfish/Finned*/Sashimi*):
+                                 // `pattern_axis` encodes the *base-axis orientation* of the pattern
+                                 // (Row when bases are rows, Col when bases are columns). Kraken's
+                                 // chain-verified eliminations are not confined to one axis, so
+                                 // `elimination_axis` is left None rather than guessing a cover line. (gh#39)
+                                 .pattern_axis = by_row ? RegionType::Row : RegionType::Col,
+                                 .position_roles = std::move(roles)}};
     }
 
     /// A swept cover target (originally empty with `value` allowed) loses `value` after the fin

--- a/src/core/strategies/sashimi_jellyfish_strategy.h
+++ b/src/core/strategies/sashimi_jellyfish_strategy.h
@@ -146,7 +146,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(r1 + 1), static_cast<int>(r2 + 1),
                                                              static_cast<int>(r3 + 1), static_cast<int>(r4 + 1)},
-                                                  .region_type = RegionType::Row,
+                                                  .pattern_axis = RegionType::Row,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;
@@ -238,7 +239,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(c1 + 1), static_cast<int>(c2 + 1),
                                                              static_cast<int>(c3 + 1), static_cast<int>(c4 + 1)},
-                                                  .region_type = RegionType::Col,
+                                                  .pattern_axis = RegionType::Col,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;

--- a/src/core/strategies/sashimi_swordfish_strategy.h
+++ b/src/core/strategies/sashimi_swordfish_strategy.h
@@ -139,7 +139,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(r1 + 1), static_cast<int>(r2 + 1),
                                                              static_cast<int>(r3 + 1)},
-                                                  .region_type = RegionType::Row,
+                                                  .pattern_axis = RegionType::Row,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;
@@ -224,7 +225,8 @@ private:
                              .explanation_data = {.positions = positions,
                                                   .values = {value, static_cast<int>(c1 + 1), static_cast<int>(c2 + 1),
                                                              static_cast<int>(c3 + 1)},
-                                                  .region_type = RegionType::Col,
+                                                  .pattern_axis = RegionType::Col,
+                                                  .elimination_axis = RegionType::Box,
                                                   .position_roles = std::move(roles)}};
         }
         return std::nullopt;

--- a/src/core/strategies/sashimi_x_wing_strategy.h
+++ b/src/core/strategies/sashimi_x_wing_strategy.h
@@ -121,7 +121,8 @@ private:
                             .rating = getTechniqueRating(SolvingTechnique::SashimiXWing),
                             .explanation_data = {.positions = positions,
                                                  .values = {value, static_cast<int>(r1 + 1), static_cast<int>(r2 + 1)},
-                                                 .region_type = RegionType::Row,
+                                                 .pattern_axis = RegionType::Row,
+                                                 .elimination_axis = RegionType::Box,
                                                  .position_roles = std::move(roles)}};
                     }
                 }
@@ -190,7 +191,8 @@ private:
                             .rating = getTechniqueRating(SolvingTechnique::SashimiXWing),
                             .explanation_data = {.positions = positions,
                                                  .values = {value, static_cast<int>(c1 + 1), static_cast<int>(c2 + 1)},
-                                                 .region_type = RegionType::Col,
+                                                 .pattern_axis = RegionType::Col,
+                                                 .elimination_axis = RegionType::Box,
                                                  .position_roles = std::move(roles)}};
                     }
                 }

--- a/src/core/strategies/swordfish_strategy.h
+++ b/src/core/strategies/swordfish_strategy.h
@@ -131,8 +131,8 @@ private:
                                                                 static_cast<int>(union_cols[0] + 1),
                                                                 static_cast<int>(union_cols[1] + 1),
                                                                 static_cast<int>(union_cols[2] + 1)},
-                                                     .region_type = RegionType::Row,
-                                                     .region_index = r1}};
+                                                     .pattern_axis = RegionType::Row,
+                                                     .elimination_axis = RegionType::Col}};
                         }
                     }
                 }
@@ -214,8 +214,8 @@ private:
                                                                 static_cast<int>(union_rows[0] + 1),
                                                                 static_cast<int>(union_rows[1] + 1),
                                                                 static_cast<int>(union_rows[2] + 1)},
-                                                     .region_type = RegionType::Col,
-                                                     .region_index = c1}};
+                                                     .pattern_axis = RegionType::Col,
+                                                     .elimination_axis = RegionType::Row}};
                         }
                     }
                 }

--- a/src/core/strategies/x_wing_strategy.h
+++ b/src/core/strategies/x_wing_strategy.h
@@ -116,10 +116,8 @@ private:
                                                                                 Position{.row = row2, .col = col1},
                                                                                 Position{.row = row2, .col = col2}},
                                                                   .values = {value},
-                                                                  .region_type = RegionType::Row,
-                                                                  .region_index = row1,
-                                                                  .secondary_region_type = RegionType::Row,
-                                                                  .secondary_region_index = row2}};
+                                                                  .pattern_axis = RegionType::Row,
+                                                                  .elimination_axis = RegionType::Col}};
                         }
                     }
                 }
@@ -183,10 +181,8 @@ private:
                                                                                 Position{.row = row2, .col = col1},
                                                                                 Position{.row = row2, .col = col2}},
                                                                   .values = {value},
-                                                                  .region_type = RegionType::Col,
-                                                                  .region_index = col1,
-                                                                  .secondary_region_type = RegionType::Col,
-                                                                  .secondary_region_index = col2}};
+                                                                  .pattern_axis = RegionType::Col,
+                                                                  .elimination_axis = RegionType::Row}};
                         }
                     }
                 }

--- a/tests/helpers/fixture_serializer.cpp
+++ b/tests/helpers/fixture_serializer.cpp
@@ -87,6 +87,8 @@ YAML::Node serializeSnapshot(const FixtureSnapshot& s) {
     }
     training["region_type"] = s.region_type;
     training["region_index"] = s.region_index;
+    training["pattern_axis"] = s.pattern_axis;
+    training["elimination_axis"] = s.elimination_axis;
     if (s.technique_subtype >= 0) {
         training["technique_subtype"] = s.technique_subtype;
     }
@@ -149,6 +151,8 @@ FixtureSnapshot deserializeSnapshot(const YAML::Node& node) {
     }
     s.region_type = training["region_type"].as<std::string>("");
     s.region_index = training["region_index"].as<size_t>(0);
+    s.pattern_axis = training["pattern_axis"].as<std::string>("");
+    s.elimination_axis = training["elimination_axis"].as<std::string>("");
     s.technique_subtype = training["technique_subtype"].as<int>(-1);
 
     return s;

--- a/tests/helpers/fixture_serializer.h
+++ b/tests/helpers/fixture_serializer.h
@@ -63,6 +63,8 @@ struct FixtureSnapshot {
     std::vector<std::string> position_roles;
     std::string region_type;
     size_t region_index{};
+    std::string pattern_axis;      // fish base-axis orientation (gh#39)
+    std::string elimination_axis;  // axis/region where eliminations land (gh#39)
     int technique_subtype{-1};
 };
 

--- a/tests/unit/test_finned_jellyfish_strategy.cpp
+++ b/tests/unit/test_finned_jellyfish_strategy.cpp
@@ -111,6 +111,7 @@ TEST_CASE("FinnedJellyfishStrategy - Detects row-based finned jellyfish", "[finn
     }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("FinnedJellyfishStrategy - Col-based finned Jellyfish detection", "[finned_jellyfish]") {
     // Fish cols {0,3,6,7}. Cols 0,3: rows {0,3,6}. Col 6: rows {0,3,7}. Col 7: rows {0,3,7,8} (fin=8).
     // Union = {0,3,6,7,8} = 5 rows. fin_row=8, fin_col=7, fin_box=8 (rows 6-8, cols 6-8).

--- a/tests/unit/test_finned_jellyfish_strategy.cpp
+++ b/tests/unit/test_finned_jellyfish_strategy.cpp
@@ -143,7 +143,7 @@ TEST_CASE("FinnedJellyfishStrategy - Col-based finned Jellyfish detection", "[fi
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::FinnedJellyfish);
     // Finned fish eliminate inside the fin's box. (gh#39)
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Box));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_finned_jellyfish_strategy.cpp
+++ b/tests/unit/test_finned_jellyfish_strategy.cpp
@@ -142,6 +142,8 @@ TEST_CASE("FinnedJellyfishStrategy - Col-based finned Jellyfish detection", "[fi
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::FinnedJellyfish);
+    // Finned fish eliminate inside the fin's box. (gh#39)
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_finned_swordfish_strategy.cpp
+++ b/tests/unit/test_finned_swordfish_strategy.cpp
@@ -136,8 +136,8 @@ TEST_CASE("FinnedSwordfishStrategy - Col-based finned Swordfish detection", "[fi
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::FinnedSwordfish);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Box));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_finned_swordfish_strategy.cpp
+++ b/tests/unit/test_finned_swordfish_strategy.cpp
@@ -110,6 +110,7 @@ TEST_CASE("FinnedSwordfishStrategy - Row-based finned Swordfish detection", "[fi
     }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("FinnedSwordfishStrategy - Col-based finned Swordfish detection", "[finned_swordfish]") {
     // Fish cols {0,3,6}. Cols 0,3: rows {0,3,6}. Col 6: rows {0,3,6,7} (fin at row 7).
     // Union = {0,3,6,7} = 4 rows. fin_row=7, fin_col=6, fin_box=8 (rows 6-8, cols 6-8).

--- a/tests/unit/test_finned_swordfish_strategy.cpp
+++ b/tests/unit/test_finned_swordfish_strategy.cpp
@@ -136,7 +136,8 @@ TEST_CASE("FinnedSwordfishStrategy - Col-based finned Swordfish detection", "[fi
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::FinnedSwordfish);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_finned_x_wing_strategy.cpp
+++ b/tests/unit/test_finned_x_wing_strategy.cpp
@@ -159,6 +159,7 @@ TEST_CASE("FinnedXWingStrategy - Explanation contains relevant info", "[finned_x
     REQUIRE(result->explanation.find("fin") != std::string::npos);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("FinnedXWingStrategy - Col-based finned X-Wing detection", "[finned_x_wing]") {
     // base_col=0: value 5 at rows {3,6} (exactly 2)
     // fin_col=6: value 5 at rows {3,6,8} (exactly 3, base rows match, fin_row=8)

--- a/tests/unit/test_finned_x_wing_strategy.cpp
+++ b/tests/unit/test_finned_x_wing_strategy.cpp
@@ -185,7 +185,8 @@ TEST_CASE("FinnedXWingStrategy - Col-based finned X-Wing detection", "[finned_x_
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::FinnedXWing);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_finned_x_wing_strategy.cpp
+++ b/tests/unit/test_finned_x_wing_strategy.cpp
@@ -185,8 +185,8 @@ TEST_CASE("FinnedXWingStrategy - Col-based finned X-Wing detection", "[finned_x_
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::FinnedXWing);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Box));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_fixture_generator.cpp
+++ b/tests/unit/test_fixture_generator.cpp
@@ -98,6 +98,8 @@ const std::string CONFIG_PATH = DATA_DIR + "/generator_config.yaml";
     }
     snapshot.region_type = std::string(getRegionTypeName(step.explanation_data.region_type));
     snapshot.region_index = step.explanation_data.region_index;
+    snapshot.pattern_axis = std::string(getRegionTypeName(step.explanation_data.pattern_axis));
+    snapshot.elimination_axis = std::string(getRegionTypeName(step.explanation_data.elimination_axis));
     snapshot.technique_subtype = step.explanation_data.technique_subtype;
 
     return snapshot;
@@ -358,4 +360,33 @@ TEST_CASE("Generate strategy fixture data", "[.][fixtures][generator]") {
     }
 
     printCoverageSummary(state.coverage);
+}
+
+TEST_CASE("Fixture serializer round-trips fish axis fields", "[fixtures][serializer]") {
+    // gh#39: pattern_axis (base orientation) and elimination_axis (where elims land)
+    // must survive a write/read cycle alongside the legacy region_type/region_index.
+    FixtureSnapshot in;
+    in.id = "axis_roundtrip";
+    in.seed = 42;
+    in.clue_count = 30;
+    in.rating = 5.2;
+    in.board_flat = std::string(static_cast<size_t>(TOTAL_CELLS), '0');
+    in.solution_flat = std::string(static_cast<size_t>(TOTAL_CELLS), '0');
+    in.board_at_step = std::string(static_cast<size_t>(TOTAL_CELLS), '0');
+    in.technique = "Finned X-Wing";
+    in.technique_id = static_cast<int>(SolvingTechnique::FinnedXWing);
+    in.step_type = "Elimination";
+    in.se_rating = 5.2;
+    in.eliminations = {FixtureElim{.row = 4, .col = 7, .value = 6}};
+    in.pattern_axis = "Row";
+    in.elimination_axis = "Box";
+
+    const auto path = (std::filesystem::temp_directory_path() / "sudoku_axis_roundtrip.yaml").string();
+    writeFixtureFile(path, "Hard", {in});
+    auto out = readFixtureFile(path);
+    std::filesystem::remove(path);
+
+    REQUIRE(out.size() == 1);
+    CHECK(out[0].pattern_axis == "Row");
+    CHECK(out[0].elimination_axis == "Box");
 }

--- a/tests/unit/test_jellyfish_strategy.cpp
+++ b/tests/unit/test_jellyfish_strategy.cpp
@@ -109,6 +109,7 @@ TEST_CASE("JellyfishStrategy - Explanation contains relevant info", "[jellyfish]
     REQUIRE(result->explanation.find("eliminates") != std::string::npos);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("JellyfishStrategy - Col-based Jellyfish detection", "[jellyfish]") {
     // Confine value 5 to fish rows {0,2,4,6} in fish cols {0,2,5,7}.
     // Row-based: pattern exists but elimination targets (non-fish rows in those cols)

--- a/tests/unit/test_jellyfish_strategy.cpp
+++ b/tests/unit/test_jellyfish_strategy.cpp
@@ -131,7 +131,8 @@ TEST_CASE("JellyfishStrategy - Col-based Jellyfish detection", "[jellyfish]") {
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::Jellyfish);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Row);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_jellyfish_strategy.cpp
+++ b/tests/unit/test_jellyfish_strategy.cpp
@@ -131,8 +131,8 @@ TEST_CASE("JellyfishStrategy - Col-based Jellyfish detection", "[jellyfish]") {
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::Jellyfish);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Row);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Row));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_kraken_fish_strategy.cpp
+++ b/tests/unit/test_kraken_fish_strategy.cpp
@@ -199,8 +199,10 @@ TEST_CASE("KrakenFishStrategy - non-vacuous Kraken omits in-fin-box elims, full 
     // and this changes, flag it for review rather than silently passing on a weaker deduction.
     REQUIRE(eliminatesOnly(result, 2, 3, 1));
 
-    // Row-based fish: region_type encodes the base-axis orientation.
-    REQUIRE((result.has_value() && result->explanation_data.region_type == RegionType::Row));
+    // Row-based fish: pattern_axis encodes the base-axis orientation; Kraken chain
+    // eliminations are not a single axis, so elimination_axis stays None. (gh#39)
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Row));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::None));
 }
 
 // Regression for issue #40 (the 2026-05-25 audit observation at CODE_REVIEW:1114):
@@ -258,8 +260,9 @@ TEST_CASE("KrakenFishStrategy - vacuous fin contradiction reports fin-exclusion"
     REQUIRE((result.has_value() && result->explanation.contains("impossible")));
     REQUIRE((result.has_value() && result->explanation.contains("fin")));
 
-    // Base-axis orientation preserved (issue #39 scope untouched).
-    REQUIRE((result.has_value() && result->explanation_data.region_type == RegionType::Row));
+    // Base-axis orientation preserved on pattern_axis; elimination_axis None for chain elims. (gh#39)
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Row));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::None));
 }
 
 // Regression for issue #59 (the HIGH finding from the bmad-code-review pass on PR #58):

--- a/tests/unit/test_localized_explanations.cpp
+++ b/tests/unit/test_localized_explanations.cpp
@@ -241,7 +241,7 @@ TEST_CASE("getLocalizedExplanation - XWing row-based", "[localized_explanations]
         makeStep(SolvingTechnique::XWing,
                  {.positions = {{.row = 1, .col = 2}, {.row = 1, .col = 7}, {.row = 5, .col = 2}, {.row = 5, .col = 7}},
                   .values = {6},
-                  .region_type = RegionType::Row});
+                  .pattern_axis = RegionType::Row});
 
     auto result = getLocalizedExplanation(step);
     REQUIRE(result ==
@@ -253,7 +253,7 @@ TEST_CASE("getLocalizedExplanation - XWing col-based", "[localized_explanations]
         makeStep(SolvingTechnique::XWing,
                  {.positions = {{.row = 0, .col = 3}, {.row = 4, .col = 3}, {.row = 0, .col = 7}, {.row = 4, .col = 7}},
                   .values = {2},
-                  .region_type = RegionType::Col});
+                  .pattern_axis = RegionType::Col});
 
     auto result = getLocalizedExplanation(step);
     REQUIRE(result == "X-Wing on value 2 in Columns 4 and 4, Rows 1 and 1 eliminates 2 from other cells in those rows");
@@ -532,7 +532,7 @@ TEST_CASE("getLocalizedExplanation positions-too-few fallbacks", "[localized_exp
         auto step = makeStep(SolvingTechnique::XWing,
                              {.positions = {{.row = 1, .col = 2}, {.row = 1, .col = 7}, {.row = 5, .col = 2}},
                               .values = {6},
-                              .region_type = RegionType::Row},
+                              .pattern_axis = RegionType::Row},
                              "raw xw row");
         REQUIRE(getLocalizedExplanation(step) == "raw xw row");
     }
@@ -541,7 +541,7 @@ TEST_CASE("getLocalizedExplanation positions-too-few fallbacks", "[localized_exp
         auto step = makeStep(SolvingTechnique::XWing,
                              {.positions = {{.row = 0, .col = 3}, {.row = 4, .col = 3}, {.row = 0, .col = 7}},
                               .values = {2},
-                              .region_type = RegionType::Col},
+                              .pattern_axis = RegionType::Col},
                              "raw xw col");
         REQUIRE(getLocalizedExplanation(step) == "raw xw col");
     }
@@ -657,20 +657,20 @@ TEST_CASE("getLocalizedExplanation - Swordfish", "[localized_explanations]") {
 
     SECTION("Row-based Swordfish") {
         auto step =
-            makeStep(SolvingTechnique::Swordfish, {.values = {5, 1, 2, 3, 4, 5, 6}, .region_type = RegionType::Row});
+            makeStep(SolvingTechnique::Swordfish, {.values = {5, 1, 2, 3, 4, 5, 6}, .pattern_axis = RegionType::Row});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Col-based Swordfish") {
         auto step =
-            makeStep(SolvingTechnique::Swordfish, {.values = {5, 1, 2, 3, 4, 5, 6}, .region_type = RegionType::Col});
+            makeStep(SolvingTechnique::Swordfish, {.values = {5, 1, 2, 3, 4, 5, 6}, .pattern_axis = RegionType::Col});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Fallback: values too few") {
-        auto step = makeStep(SolvingTechnique::Swordfish, {.values = {5, 1}, .region_type = RegionType::Row},
+        auto step = makeStep(SolvingTechnique::Swordfish, {.values = {5, 1}, .pattern_axis = RegionType::Row},
                              "swordfish fallback");
         auto result = getLocalizedExplanation(step);
         REQUIRE(result == "swordfish fallback");
@@ -678,7 +678,7 @@ TEST_CASE("getLocalizedExplanation - Swordfish", "[localized_explanations]") {
 
     SECTION("Fallback: region_type None") {
         auto step = makeStep(SolvingTechnique::Swordfish,
-                             {.values = {5, 1, 2, 3, 4, 5, 6}, .region_type = RegionType::None}, "swordfish fallback");
+                             {.values = {5, 1, 2, 3, 4, 5, 6}, .pattern_axis = RegionType::None}, "swordfish fallback");
         auto result = getLocalizedExplanation(step);
         REQUIRE(result == "swordfish fallback");
     }
@@ -854,26 +854,26 @@ TEST_CASE("getLocalizedExplanation - FinnedXWing", "[localized_explanations]") {
 
     SECTION("Row-based FinnedXWing") {
         auto step = makeStep(SolvingTechnique::FinnedXWing,
-                             {.positions = fin_pos, .values = vals, .region_type = RegionType::Row});
+                             {.positions = fin_pos, .values = vals, .pattern_axis = RegionType::Row});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Col-based FinnedXWing") {
         auto step = makeStep(SolvingTechnique::FinnedXWing,
-                             {.positions = fin_pos, .values = vals, .region_type = RegionType::Col});
+                             {.positions = fin_pos, .values = vals, .pattern_axis = RegionType::Col});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Fallback: values empty") {
-        auto step = makeStep(SolvingTechnique::FinnedXWing, {.positions = fin_pos, .region_type = RegionType::Row},
+        auto step = makeStep(SolvingTechnique::FinnedXWing, {.positions = fin_pos, .pattern_axis = RegionType::Row},
                              "finxwing fallback");
         REQUIRE(getLocalizedExplanation(step) == "finxwing fallback");
     }
 
     SECTION("Fallback: positions empty (second guard)") {
-        auto step = makeStep(SolvingTechnique::FinnedXWing, {.values = vals, .region_type = RegionType::Row},
+        auto step = makeStep(SolvingTechnique::FinnedXWing, {.values = vals, .pattern_axis = RegionType::Row},
                              "finxwing fallback");
         REQUIRE(getLocalizedExplanation(step) == "finxwing fallback");
     }
@@ -916,20 +916,20 @@ TEST_CASE("getLocalizedExplanation - Jellyfish", "[localized_explanations]") {
     const std::vector<int> vals = {5, 1, 2, 3, 4, 5, 6, 7, 8};
 
     SECTION("Row-based Jellyfish") {
-        auto step = makeStep(SolvingTechnique::Jellyfish, {.values = vals, .region_type = RegionType::Row});
+        auto step = makeStep(SolvingTechnique::Jellyfish, {.values = vals, .pattern_axis = RegionType::Row});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Col-based Jellyfish") {
-        auto step = makeStep(SolvingTechnique::Jellyfish, {.values = vals, .region_type = RegionType::Col});
+        auto step = makeStep(SolvingTechnique::Jellyfish, {.values = vals, .pattern_axis = RegionType::Col});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Fallback: values too few") {
         auto step =
-            makeStep(SolvingTechnique::Jellyfish, {.values = {5, 1}, .region_type = RegionType::Row}, "jf fallback");
+            makeStep(SolvingTechnique::Jellyfish, {.values = {5, 1}, .pattern_axis = RegionType::Row}, "jf fallback");
         REQUIRE(getLocalizedExplanation(step) == "jf fallback");
     }
 }
@@ -941,20 +941,20 @@ TEST_CASE("getLocalizedExplanation - FinnedSwordfish", "[localized_explanations]
 
     SECTION("Row-based FinnedSwordfish") {
         auto step = makeStep(SolvingTechnique::FinnedSwordfish,
-                             {.positions = fin_pos, .values = vals, .region_type = RegionType::Row});
+                             {.positions = fin_pos, .values = vals, .pattern_axis = RegionType::Row});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Col-based FinnedSwordfish") {
         auto step = makeStep(SolvingTechnique::FinnedSwordfish,
-                             {.positions = fin_pos, .values = vals, .region_type = RegionType::Col});
+                             {.positions = fin_pos, .values = vals, .pattern_axis = RegionType::Col});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Fallback: positions empty") {
-        auto step = makeStep(SolvingTechnique::FinnedSwordfish, {.values = vals, .region_type = RegionType::Row},
+        auto step = makeStep(SolvingTechnique::FinnedSwordfish, {.values = vals, .pattern_axis = RegionType::Row},
                              "fsf fallback");
         REQUIRE(getLocalizedExplanation(step) == "fsf fallback");
     }
@@ -1004,21 +1004,21 @@ TEST_CASE("getLocalizedExplanation - FinnedJellyfish", "[localized_explanations]
 
     SECTION("Row-based FinnedJellyfish") {
         auto step = makeStep(SolvingTechnique::FinnedJellyfish,
-                             {.positions = fin_pos, .values = vals, .region_type = RegionType::Row});
+                             {.positions = fin_pos, .values = vals, .pattern_axis = RegionType::Row});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Col-based FinnedJellyfish") {
         auto step = makeStep(SolvingTechnique::FinnedJellyfish,
-                             {.positions = fin_pos, .values = vals, .region_type = RegionType::Col});
+                             {.positions = fin_pos, .values = vals, .pattern_axis = RegionType::Col});
         auto result = getLocalizedExplanation(step);
         REQUIRE(!result.empty());
     }
 
     SECTION("Fallback: values too few") {
         auto step = makeStep(SolvingTechnique::FinnedJellyfish,
-                             {.positions = fin_pos, .values = {5}, .region_type = RegionType::Row}, "fjf fallback");
+                             {.positions = fin_pos, .values = {5}, .pattern_axis = RegionType::Row}, "fjf fallback");
         REQUIRE(getLocalizedExplanation(step) == "fjf fallback");
     }
 }

--- a/tests/unit/test_localized_explanations_advanced.cpp
+++ b/tests/unit/test_localized_explanations_advanced.cpp
@@ -52,7 +52,7 @@ namespace {
 TEST_CASE("getLocalizedExplanation - Swordfish row-based", "[localized_explanations_advanced]") {
     // values = {candidate, r1, r2, r3, c1, c2, c3}
     auto step = makeStep(SolvingTechnique::Swordfish,
-                         {.positions = {}, .values = {3, 1, 4, 7, 2, 5, 8}, .region_type = RegionType::Row});
+                         {.positions = {}, .values = {3, 1, 4, 7, 2, 5, 8}, .pattern_axis = RegionType::Row});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result ==
             "Swordfish on value 3 in Rows 1, 4, 7 and Columns 2, 5, 8 eliminates 3 from other cells in those columns");
@@ -60,7 +60,7 @@ TEST_CASE("getLocalizedExplanation - Swordfish row-based", "[localized_explanati
 
 TEST_CASE("getLocalizedExplanation - Swordfish col-based", "[localized_explanations_advanced]") {
     auto step = makeStep(SolvingTechnique::Swordfish,
-                         {.positions = {}, .values = {5, 2, 6, 9, 3, 7, 1}, .region_type = RegionType::Col});
+                         {.positions = {}, .values = {5, 2, 6, 9, 3, 7, 1}, .pattern_axis = RegionType::Col});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result ==
             "Swordfish on value 5 in Columns 2, 6, 9 and Rows 3, 7, 1 eliminates 5 from other cells in those rows");
@@ -68,7 +68,7 @@ TEST_CASE("getLocalizedExplanation - Swordfish col-based", "[localized_explanati
 
 TEST_CASE("getLocalizedExplanation - Swordfish fallback on insufficient values", "[localized_explanations_advanced]") {
     auto step = makeStep(SolvingTechnique::Swordfish,
-                         {.positions = {}, .values = {3, 1, 4}, .region_type = RegionType::Row}, "raw swordfish");
+                         {.positions = {}, .values = {3, 1, 4}, .pattern_axis = RegionType::Row}, "raw swordfish");
     REQUIRE(getLocalizedExplanation(step) == "raw swordfish");
 }
 
@@ -252,7 +252,7 @@ TEST_CASE("getLocalizedExplanation - FinnedXWing row-based", "[localized_explana
     // values = {candidate, row1, row2, col1, col2}; positions.back() = fin
     auto step =
         makeStep(SolvingTechnique::FinnedXWing,
-                 {.positions = {{.row = 4, .col = 2}}, .values = {7, 2, 5, 3, 8}, .region_type = RegionType::Row});
+                 {.positions = {{.row = 4, .col = 2}}, .values = {7, 2, 5, 3, 8}, .pattern_axis = RegionType::Row});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result == "Finned X-Wing on value 7 in Rows 2 and 5, Columns 3 and 8 with fin at R5C3 — eliminates 7 from "
                       "cells in fin's box");
@@ -261,15 +261,15 @@ TEST_CASE("getLocalizedExplanation - FinnedXWing row-based", "[localized_explana
 TEST_CASE("getLocalizedExplanation - FinnedXWing col-based", "[localized_explanations_advanced]") {
     auto step =
         makeStep(SolvingTechnique::FinnedXWing,
-                 {.positions = {{.row = 0, .col = 6}}, .values = {4, 3, 7, 1, 6}, .region_type = RegionType::Col});
+                 {.positions = {{.row = 0, .col = 6}}, .values = {4, 3, 7, 1, 6}, .pattern_axis = RegionType::Col});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result == "Finned X-Wing on value 4 in Columns 3 and 7, Rows 1 and 6 with fin at R1C7 — eliminates 4 from "
                       "cells in fin's box");
 }
 
 TEST_CASE("getLocalizedExplanation - FinnedXWing fallback on no values", "[localized_explanations_advanced]") {
-    auto step = makeStep(SolvingTechnique::FinnedXWing, {.positions = {}, .values = {}, .region_type = RegionType::Row},
-                         "raw finned x");
+    auto step = makeStep(SolvingTechnique::FinnedXWing,
+                         {.positions = {}, .values = {}, .pattern_axis = RegionType::Row}, "raw finned x");
     REQUIRE(getLocalizedExplanation(step) == "raw finned x");
 }
 
@@ -313,7 +313,7 @@ TEST_CASE("getLocalizedExplanation - BUG fallback", "[localized_explanations_adv
 TEST_CASE("getLocalizedExplanation - Jellyfish row-based", "[localized_explanations_advanced]") {
     // values = {candidate, r1, r2, r3, r4, c1, c2, c3, c4} (1-indexed)
     auto step = makeStep(SolvingTechnique::Jellyfish,
-                         {.positions = {}, .values = {2, 1, 3, 6, 8, 2, 4, 7, 9}, .region_type = RegionType::Row});
+                         {.positions = {}, .values = {2, 1, 3, 6, 8, 2, 4, 7, 9}, .pattern_axis = RegionType::Row});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result == "Jellyfish on value 2 in Rows 1, 3, 6, 8 and Columns 2, 4, 7, 9 eliminates 2 from other cells in "
                       "those columns");
@@ -321,7 +321,7 @@ TEST_CASE("getLocalizedExplanation - Jellyfish row-based", "[localized_explanati
 
 TEST_CASE("getLocalizedExplanation - Jellyfish col-based", "[localized_explanations_advanced]") {
     auto step = makeStep(SolvingTechnique::Jellyfish,
-                         {.positions = {}, .values = {5, 2, 4, 7, 9, 1, 3, 6, 8}, .region_type = RegionType::Col});
+                         {.positions = {}, .values = {5, 2, 4, 7, 9, 1, 3, 6, 8}, .pattern_axis = RegionType::Col});
     auto result = getLocalizedExplanation(step);
     REQUIRE(
         result ==
@@ -330,7 +330,7 @@ TEST_CASE("getLocalizedExplanation - Jellyfish col-based", "[localized_explanati
 
 TEST_CASE("getLocalizedExplanation - Jellyfish fallback", "[localized_explanations_advanced]") {
     auto step = makeStep(SolvingTechnique::Jellyfish,
-                         {.positions = {}, .values = {2, 1, 3}, .region_type = RegionType::Row}, "raw jellyfish");
+                         {.positions = {}, .values = {2, 1, 3}, .pattern_axis = RegionType::Row}, "raw jellyfish");
     REQUIRE(getLocalizedExplanation(step) == "raw jellyfish");
 }
 
@@ -340,16 +340,18 @@ TEST_CASE("getLocalizedExplanation - Jellyfish fallback", "[localized_explanatio
 
 TEST_CASE("getLocalizedExplanation - FinnedSwordfish row-based", "[localized_explanations_advanced]") {
     // values = {candidate, row/col1, row/col2, row/col3}; positions.back() = fin
-    auto step = makeStep(SolvingTechnique::FinnedSwordfish,
-                         {.positions = {{.row = 4, .col = 3}}, .values = {6, 2, 5, 8}, .region_type = RegionType::Row});
+    auto step =
+        makeStep(SolvingTechnique::FinnedSwordfish,
+                 {.positions = {{.row = 4, .col = 3}}, .values = {6, 2, 5, 8}, .pattern_axis = RegionType::Row});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result ==
             "Finned Swordfish on value 6 in Rows 2, 5, 8 with fin at R5C4 — eliminates 6 from cells in fin's box");
 }
 
 TEST_CASE("getLocalizedExplanation - FinnedSwordfish col-based", "[localized_explanations_advanced]") {
-    auto step = makeStep(SolvingTechnique::FinnedSwordfish,
-                         {.positions = {{.row = 6, .col = 3}}, .values = {3, 1, 4, 7}, .region_type = RegionType::Col});
+    auto step =
+        makeStep(SolvingTechnique::FinnedSwordfish,
+                 {.positions = {{.row = 6, .col = 3}}, .values = {3, 1, 4, 7}, .pattern_axis = RegionType::Col});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result ==
             "Finned Swordfish on value 3 in Columns 1, 4, 7 with fin at R7C4 — eliminates 3 from cells in fin's box");
@@ -357,7 +359,7 @@ TEST_CASE("getLocalizedExplanation - FinnedSwordfish col-based", "[localized_exp
 
 TEST_CASE("getLocalizedExplanation - FinnedSwordfish fallback", "[localized_explanations_advanced]") {
     auto step = makeStep(SolvingTechnique::FinnedSwordfish,
-                         {.positions = {}, .values = {6, 2, 5, 8}, .region_type = RegionType::Row}, "raw fs");
+                         {.positions = {}, .values = {6, 2, 5, 8}, .pattern_axis = RegionType::Row}, "raw fs");
     REQUIRE(getLocalizedExplanation(step) == "raw fs");
 }
 
@@ -406,7 +408,7 @@ TEST_CASE("getLocalizedExplanation - FinnedJellyfish row-based", "[localized_exp
     // values = {candidate, row/col1..4}; positions.back() = fin
     auto step =
         makeStep(SolvingTechnique::FinnedJellyfish,
-                 {.positions = {{.row = 2, .col = 4}}, .values = {8, 1, 3, 5, 7}, .region_type = RegionType::Row});
+                 {.positions = {{.row = 2, .col = 4}}, .values = {8, 1, 3, 5, 7}, .pattern_axis = RegionType::Row});
     auto result = getLocalizedExplanation(step);
     REQUIRE(result ==
             "Finned Jellyfish on value 8 in Rows 1, 3, 5, 7 with fin at R3C5 — eliminates 8 from cells in fin's box");
@@ -415,7 +417,7 @@ TEST_CASE("getLocalizedExplanation - FinnedJellyfish row-based", "[localized_exp
 TEST_CASE("getLocalizedExplanation - FinnedJellyfish col-based", "[localized_explanations_advanced]") {
     auto step =
         makeStep(SolvingTechnique::FinnedJellyfish,
-                 {.positions = {{.row = 2, .col = 4}}, .values = {8, 1, 3, 5, 7}, .region_type = RegionType::Col});
+                 {.positions = {{.row = 2, .col = 4}}, .values = {8, 1, 3, 5, 7}, .pattern_axis = RegionType::Col});
     auto result = getLocalizedExplanation(step);
     REQUIRE(
         result ==
@@ -424,7 +426,7 @@ TEST_CASE("getLocalizedExplanation - FinnedJellyfish col-based", "[localized_exp
 
 TEST_CASE("getLocalizedExplanation - FinnedJellyfish fallback", "[localized_explanations_advanced]") {
     auto step = makeStep(SolvingTechnique::FinnedJellyfish,
-                         {.positions = {}, .values = {8, 1, 3, 5, 7}, .region_type = RegionType::Row}, "raw fj");
+                         {.positions = {}, .values = {8, 1, 3, 5, 7}, .pattern_axis = RegionType::Row}, "raw fj");
     REQUIRE(getLocalizedExplanation(step) == "raw fj");
 }
 
@@ -746,7 +748,7 @@ TEST_CASE("getLocalizedExplanation - SashimiXWing fallback empty values", "[loca
 
 TEST_CASE("getLocalizedExplanation - SashimiXWing fallback insufficient values", "[localized_explanations_advanced]") {
     auto step = makeStep(SolvingTechnique::SashimiXWing,
-                         {.positions = {{.row = 1, .col = 3}}, .values = {5, 2}, .region_type = RegionType::Row},
+                         {.positions = {{.row = 1, .col = 3}}, .values = {5, 2}, .pattern_axis = RegionType::Row},
                          "raw sxw partial");
     REQUIRE(getLocalizedExplanation(step) == "raw sxw partial");
 }

--- a/tests/unit/test_sashimi_jellyfish_strategy.cpp
+++ b/tests/unit/test_sashimi_jellyfish_strategy.cpp
@@ -195,8 +195,8 @@ TEST_CASE("SashimiJellyfishStrategy - Col-based sashimi Jellyfish detection", "[
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::SashimiJellyfish);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Box));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_sashimi_jellyfish_strategy.cpp
+++ b/tests/unit/test_sashimi_jellyfish_strategy.cpp
@@ -154,6 +154,7 @@ TEST_CASE("SashimiJellyfishStrategy - Explanation contains relevant info", "[sas
     REQUIRE(result->explanation.find("fin") != std::string::npos);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("SashimiJellyfishStrategy - Col-based sashimi Jellyfish detection", "[sashimi_jellyfish]") {
     // Col 0 (sashimi): value 5 at row 0 only (exactly 1 — sashimi condition)
     // Col 2:           value 5 at rows 0, 3, 6

--- a/tests/unit/test_sashimi_jellyfish_strategy.cpp
+++ b/tests/unit/test_sashimi_jellyfish_strategy.cpp
@@ -195,7 +195,8 @@ TEST_CASE("SashimiJellyfishStrategy - Col-based sashimi Jellyfish detection", "[
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::SashimiJellyfish);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_sashimi_swordfish_strategy.cpp
+++ b/tests/unit/test_sashimi_swordfish_strategy.cpp
@@ -132,6 +132,7 @@ TEST_CASE("SashimiSwordfishStrategy - Explanation contains relevant info", "[sas
     REQUIRE(result->explanation.find("fin") != std::string::npos);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("SashimiSwordfishStrategy - Col-based sashimi Swordfish detection", "[sashimi_swordfish]") {
     // Col 0 (sashimi): value 5 at row 0 only (exactly 1 — sashimi condition)
     // Col 3:           value 5 at rows 0, 3, 6

--- a/tests/unit/test_sashimi_swordfish_strategy.cpp
+++ b/tests/unit/test_sashimi_swordfish_strategy.cpp
@@ -167,8 +167,8 @@ TEST_CASE("SashimiSwordfishStrategy - Col-based sashimi Swordfish detection", "[
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::SashimiSwordfish);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Box));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_sashimi_swordfish_strategy.cpp
+++ b/tests/unit/test_sashimi_swordfish_strategy.cpp
@@ -167,7 +167,8 @@ TEST_CASE("SashimiSwordfishStrategy - Col-based sashimi Swordfish detection", "[
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::SashimiSwordfish);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_sashimi_x_wing_strategy.cpp
+++ b/tests/unit/test_sashimi_x_wing_strategy.cpp
@@ -180,7 +180,8 @@ TEST_CASE("SashimiXWingStrategy - Col-based sashimi X-Wing detection", "[sashimi
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::SashimiXWing);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_sashimi_x_wing_strategy.cpp
+++ b/tests/unit/test_sashimi_x_wing_strategy.cpp
@@ -152,6 +152,7 @@ TEST_CASE("SashimiXWingStrategy - Explanation contains relevant info", "[sashimi
     REQUIRE(result->explanation.find("fin") != std::string::npos);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("SashimiXWingStrategy - Col-based sashimi X-Wing detection", "[sashimi_x_wing]") {
     // Col 0 (sashimi): value 5 at row 3 only (exactly 1 — sashimi condition)
     // Col 6: value 5 at rows 3, 6, and 8 (fin at row 8)

--- a/tests/unit/test_sashimi_x_wing_strategy.cpp
+++ b/tests/unit/test_sashimi_x_wing_strategy.cpp
@@ -180,8 +180,8 @@ TEST_CASE("SashimiXWingStrategy - Col-based sashimi X-Wing detection", "[sashimi
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::SashimiXWing);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Box);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Box));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_swordfish_strategy.cpp
+++ b/tests/unit/test_swordfish_strategy.cpp
@@ -197,6 +197,7 @@ TEST_CASE("SwordfishStrategy - Explanation contains relevant info", "[swordfish]
     }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("SwordfishStrategy - Col-based Swordfish detection", "[swordfish]") {
     // Confine value 5 to fish rows {0,3,6} in fish cols {1,4,7}.
     // Row-based scanner sees the same pattern but has no elimination targets

--- a/tests/unit/test_swordfish_strategy.cpp
+++ b/tests/unit/test_swordfish_strategy.cpp
@@ -219,8 +219,8 @@ TEST_CASE("SwordfishStrategy - Col-based Swordfish detection", "[swordfish]") {
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::Swordfish);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Row);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Row));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_swordfish_strategy.cpp
+++ b/tests/unit/test_swordfish_strategy.cpp
@@ -219,7 +219,8 @@ TEST_CASE("SwordfishStrategy - Col-based Swordfish detection", "[swordfish]") {
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::Swordfish);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Row);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_x_wing_strategy.cpp
+++ b/tests/unit/test_x_wing_strategy.cpp
@@ -122,8 +122,8 @@ TEST_CASE("XWingStrategy - Col-based X-Wing detection", "[x_wing]") {
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::XWing);
-    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
-    REQUIRE(result->explanation_data.elimination_axis == RegionType::Row);
+    REQUIRE((result.has_value() && result->explanation_data.pattern_axis == RegionType::Col));
+    REQUIRE((result.has_value() && result->explanation_data.elimination_axis == RegionType::Row));
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_x_wing_strategy.cpp
+++ b/tests/unit/test_x_wing_strategy.cpp
@@ -122,7 +122,8 @@ TEST_CASE("XWingStrategy - Col-based X-Wing detection", "[x_wing]") {
     REQUIRE(result.has_value());
     REQUIRE(result->type == SolveStepType::Elimination);
     REQUIRE(result->technique == SolvingTechnique::XWing);
-    REQUIRE(result->explanation_data.region_type == RegionType::Col);
+    REQUIRE(result->explanation_data.pattern_axis == RegionType::Col);
+    REQUIRE(result->explanation_data.elimination_axis == RegionType::Row);
     REQUIRE_FALSE(result->eliminations.empty());
 
     for (const auto& elim : result->eliminations) {

--- a/tests/unit/test_x_wing_strategy.cpp
+++ b/tests/unit/test_x_wing_strategy.cpp
@@ -100,6 +100,7 @@ TEST_CASE("XWingStrategy - Finds row-based X-Wing with manual setup", "[x_wing]"
     }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with candidate-setup loops; complexity is inherent to test coverage (gh#39)
 TEST_CASE("XWingStrategy - Col-based X-Wing detection", "[x_wing]") {
     // Confine value 5 to fish rows {0,3} in fish cols {1,4}.
     // Row-based sees same pattern but has no elimination targets


### PR DESCRIPTION
Closes #39.

Splits the overloaded `ExplanationData::region_type` rather than flipping its meaning (Option C from the issue).

## Correction to the issue's premise
The issue's "category 3 — set-but-ignored" list was inaccurate, which narrowed the real scope:
- **Finned×3 and Sashimi×3 DO consume the field** (orientation discriminator) — category 1, not 3.
- **FrankenFish and MutantFish never set `region_type`** at all.
- **Only KrakenFish** was genuinely set-but-unread (and already documented the convention).

So the field's value was already consistent everywhere it was set; the real gap was the missing **elimination-axis** concept + the undocumented overload — not an axis disagreement. (Option B's "flip in lockstep" framing therefore didn't apply.)

## Changes
- `ExplanationData` gains `pattern_axis` (fish base-axis orientation) and `elimination_axis` (where elims land). Additive, `None` defaults → existing designated-initializers and `operator==` unaffected.
- `region_type`/`region_index` documented as the **named-region** carrier for non-fish techniques only.
- 10 fish producers migrated off `region_type` → `pattern_axis`. `elimination_axis`: perpendicular line for basic fish, `Box` for finned/sashimi, **`None` for Kraken** (chain-verified elims aren't a single axis).
- 10 localized-template branches repointed to `pattern_axis`; rendered output **byte-for-byte identical** (enforced by `test_localized_explanations*`).
- Fixture serializer round-trips the new fields (+ new `[fixtures][serializer]` test).

## On the "load-bearing consumer" acceptance criterion
No renderer consumer was manufactured for `elimination_axis` (wiring it into unchanged wording would be theatre). Per the criterion's explicit alternative ("…or a TODO with owner"), it carries `TODO(gh#39)` pointing at a future fish-line / elimination-region highlight in `src/view/`. The only live consumer of the axis fields today is the explanation renderer.

## Tests / notes
- Green: unit (1071 cases / 15,714 assertions), integration (14), UI (13/13 offscreen). `clang-format` clean.
- **Stored fixtures NOT regenerated** — no default test reads their axis data; serializer emits the new fields going forward. Harmless stale `region_type` in stored YAML.
- No CHANGELOG entry: internal data-model only, no user-/packager-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)