### PR TITLE
fix(nightly): clang-tidy narrowing + main exception-escape, and CPD apt-index refresh

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -387,7 +387,12 @@ jobs:
 
       - name: Install Java
         if: steps.check.outputs.skip != 'true'
-        run: sudo apt-get install -y default-jre-headless
+        # Refresh the apt index first: the runner image ships a stale index that can
+        # point default-jre-headless at an openjdk patch version no longer in the pool
+        # (404 on fetch). The other apt jobs avoid this via install-qt-deps' own update.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y default-jre-headless
 
       - name: Install PMD
         if: steps.check.outputs.skip != 'true'

--- a/src/core/statistics_manager.cpp
+++ b/src/core/statistics_manager.cpp
@@ -323,7 +323,7 @@ std::array<double, DIFFICULTY_COUNT> StatisticsManager::getCompletionRates() con
 
     for (size_t i = 0; i < DIFFICULTY_COUNT; ++i) {
         if (stats.games_played[i] > 0) {
-            rates[i] = static_cast<double>(stats.games_completed[i]) / stats.games_played[i];
+            rates[i] = static_cast<double>(stats.games_completed[i]) / static_cast<double>(stats.games_played[i]);
         } else {
             rates[i] = 0.0;
         }
@@ -580,7 +580,8 @@ void StatisticsManager::updateAggregateStats(const GameStats& completed_game) co
         // Update average rating
         auto current_rating_average = cached_stats_.average_ratings[diff_index];
         cached_stats_.average_ratings[diff_index] =
-            (current_rating_average * games_count_before + completed_game.puzzle_rating) / (games_count_before + 1);
+            (current_rating_average * static_cast<double>(games_count_before) + completed_game.puzzle_rating) /
+            static_cast<double>(games_count_before + 1);
     }
 
     // Update per-difficulty stats

--- a/src/core/statistics_serializer.cpp
+++ b/src/core/statistics_serializer.cpp
@@ -339,7 +339,9 @@ std::expected<void, StatisticsError> exportAggregateStatsCsv(const AggregateStat
             // Calculate completion rate
             double completion_rate = 0.0;
             if (stats.games_played[i] > 0) {
-                completion_rate = (stats.games_completed[i] / static_cast<double>(stats.games_played[i])) * 100.0;
+                completion_rate =
+                    (static_cast<double>(stats.games_completed[i]) / static_cast<double>(stats.games_played[i])) *
+                    100.0;
             }
             file << completion_rate << ",";
 
@@ -361,7 +363,8 @@ std::expected<void, StatisticsError> exportAggregateStatsCsv(const AggregateStat
         file << stats.total_completed << ",";
         double overall_completion_rate = 0.0;
         if (stats.total_games > 0) {
-            overall_completion_rate = (stats.total_completed / static_cast<double>(stats.total_games)) * 100.0;
+            overall_completion_rate =
+                (static_cast<double>(stats.total_completed) / static_cast<double>(stats.total_games)) * 100.0;
         }
         file << overall_completion_rate << ",";
         file << "N/A,N/A,N/A,N/A,N/A\n";  // N/A for time and rating columns

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@
 #include "view_model/game_view_model.h"
 #include "view_model/training_view_model.h"
 
+#include <cstdlib>
 #include <expected>
 #include <filesystem>
 #include <memory>
@@ -139,84 +140,92 @@ std::shared_ptr<sudoku::viewmodel::GameViewModel> createViewModel() {
 }  // namespace
 
 int main(int argc, char* argv[]) {
-    QApplication qt_app(argc, argv);
-    QApplication::setApplicationName("Sudoku");
-    QApplication::setApplicationVersion(sudoku::kAppVersion);
+    try {
+        QApplication qt_app(argc, argv);
+        QApplication::setApplicationName("Sudoku");
+        QApplication::setApplicationVersion(sudoku::kAppVersion);
 
-    // Setup multi-sink logger: console + debug log file (truncated each launch)
-    auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    auto exe_dir = std::filesystem::path(QCoreApplication::applicationDirPath().toStdString());
-    auto log_path = exe_dir / "sudoku_debug.log";
-    // In sandboxed environments (Flatpak), exe_dir is read-only; use data directory instead.
-    // We detect by absence of writable bundled translations next to the executable.
-    if (!std::filesystem::exists(exe_dir / "translations")) {
-        auto log_dir = sudoku::infrastructure::AppDirectoryManager::getDefaultDirectory(
-            sudoku::infrastructure::DirectoryType::Logs);
-        std::filesystem::create_directories(log_dir);
-        log_path = log_dir / "sudoku_debug.log";
-    }
-    auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.string(), true);  // truncate=true
-    auto logger = std::make_shared<spdlog::logger>("sudoku", spdlog::sinks_init_list{console_sink, file_sink});
-    logger->set_level(spdlog::level::debug);
-    logger->flush_on(spdlog::level::debug);
-    spdlog::set_default_logger(logger);
+        // Setup multi-sink logger: console + debug log file (truncated each launch)
+        auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+        auto exe_dir = std::filesystem::path(QCoreApplication::applicationDirPath().toStdString());
+        auto log_path = exe_dir / "sudoku_debug.log";
+        // In sandboxed environments (Flatpak), exe_dir is read-only; use data directory instead.
+        // We detect by absence of writable bundled translations next to the executable.
+        if (!std::filesystem::exists(exe_dir / "translations")) {
+            auto log_dir = sudoku::infrastructure::AppDirectoryManager::getDefaultDirectory(
+                sudoku::infrastructure::DirectoryType::Logs);
+            std::filesystem::create_directories(log_dir);
+            log_path = log_dir / "sudoku_debug.log";
+        }
+        auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.string(), true);  // truncate=true
+        auto logger = std::make_shared<spdlog::logger>("sudoku", spdlog::sinks_init_list{console_sink, file_sink});
+        logger->set_level(spdlog::level::debug);
+        logger->flush_on(spdlog::level::debug);
+        spdlog::set_default_logger(logger);
 
-    spdlog::info("Starting Sudoku application with Qt6 + MVVM architecture...");
-    spdlog::info("Debug log: {}", log_path.string());
+        spdlog::info("Starting Sudoku application with Qt6 + MVVM architecture...");
+        spdlog::info("Debug log: {}", log_path.string());
 
-    setupDependencies();
+        setupDependencies();
 
-    // The Qt translator is owned by MainWindow and installed when
-    // setSettingsManager() is called below. This lets the user switch
-    // language at runtime via the Settings dialog.
-    auto& container = sudoku::core::getContainer();
-    auto view_model = createViewModel();
-    auto exercise_gen = container.resolve<sudoku::core::ITrainingExerciseGenerator>();
-    auto training_stats = container.resolve<sudoku::core::ITrainingStatisticsManager>();
-    auto training_vm = std::make_shared<sudoku::viewmodel::TrainingViewModel>(exercise_gen, training_stats);
+        // The Qt translator is owned by MainWindow and installed when
+        // setSettingsManager() is called below. This lets the user switch
+        // language at runtime via the Settings dialog.
+        auto& container = sudoku::core::getContainer();
+        auto view_model = createViewModel();
+        auto exercise_gen = container.resolve<sudoku::core::ITrainingExerciseGenerator>();
+        auto training_stats = container.resolve<sudoku::core::ITrainingStatisticsManager>();
+        auto training_vm = std::make_shared<sudoku::viewmodel::TrainingViewModel>(exercise_gen, training_stats);
 
-    auto settings_manager = container.resolve<sudoku::core::ISettingsManager>();
+        auto settings_manager = container.resolve<sudoku::core::ISettingsManager>();
 
-    sudoku::view::MainWindow main_window;
-    main_window.setViewModel(view_model);
-    main_window.setSettingsManager(settings_manager);
-    main_window.setTrainingViewModel(training_vm);
+        sudoku::view::MainWindow main_window;
+        main_window.setViewModel(view_model);
+        main_window.setSettingsManager(settings_manager);
+        main_window.setTrainingViewModel(training_vm);
 
-    // Try to load auto-save, otherwise start new game
-    auto save_manager = container.resolve<sudoku::core::ISaveManager>();
-    auto default_difficulty =
-        settings_manager ? settings_manager->getSettings().default_difficulty : sudoku::core::Difficulty::Medium;
-    if (save_manager->hasAutoSave()) {
-        spdlog::info("Auto-save detected, attempting to load...");
-        auto result = save_manager->loadAutoSave();
-        if (result.has_value()) {
-            if (result->is_complete) {
-                spdlog::info("Auto-save contains completed game, starting fresh");
-                view_model->startNewGame(default_difficulty);
+        // Try to load auto-save, otherwise start new game
+        auto save_manager = container.resolve<sudoku::core::ISaveManager>();
+        auto default_difficulty =
+            settings_manager ? settings_manager->getSettings().default_difficulty : sudoku::core::Difficulty::Medium;
+        if (save_manager->hasAutoSave()) {
+            spdlog::info("Auto-save detected, attempting to load...");
+            auto result = save_manager->loadAutoSave();
+            if (result.has_value()) {
+                if (result->is_complete) {
+                    spdlog::info("Auto-save contains completed game, starting fresh");
+                    view_model->startNewGame(default_difficulty);
+                } else {
+                    view_model->restoreGameState(*result);
+                }
             } else {
-                view_model->restoreGameState(*result);
+                spdlog::warn("Auto-save load failed: {}, starting new game", static_cast<int>(result.error()));
+                view_model->startNewGame(default_difficulty);
             }
         } else {
-            spdlog::warn("Auto-save load failed: {}, starting new game", static_cast<int>(result.error()));
+            spdlog::info("No auto-save found, starting new game");
             view_model->startNewGame(default_difficulty);
         }
-    } else {
-        spdlog::info("No auto-save found, starting new game");
-        view_model->startNewGame(default_difficulty);
+
+        main_window.show();
+
+        spdlog::info("Application initialized successfully, entering Qt event loop");
+        int result = QApplication::exec();
+
+        // Auto-save on exit
+        if (view_model->isGameStateDirty()) {
+            view_model->autoSave();
+            spdlog::info("Game state saved on exit");
+        }
+
+        sudoku::core::getContainer().clear();
+        spdlog::info("Sudoku application terminated successfully");
+        return result;
+    } catch (const std::exception& e) {
+        spdlog::critical("Fatal: unhandled exception: {}", e.what());
+        return EXIT_FAILURE;
+    } catch (...) {
+        spdlog::critical("Fatal: unknown unhandled exception");
+        return EXIT_FAILURE;
     }
-
-    main_window.show();
-
-    spdlog::info("Application initialized successfully, entering Qt event loop");
-    int result = QApplication::exec();
-
-    // Auto-save on exit
-    if (view_model->isGameStateDirty()) {
-        view_model->autoSave();
-        spdlog::info("Game state saved on exit");
-    }
-
-    sudoku::core::getContainer().clear();
-    spdlog::info("Sudoku application terminated successfully");
-    return result;
 }

--- a/src/view_model/game_view_model_state.cpp
+++ b/src/view_model/game_view_model_state.cpp
@@ -29,6 +29,7 @@
 #include <array>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <expected>
 #include <filesystem>
 #include <memory>
@@ -399,14 +400,15 @@ StatsDisplay GameViewModel::createStatsDisplay(const core::AggregateStats& stats
     StatsDisplay display;
     display.games_played = stats.total_games;
     display.games_completed = stats.total_completed;
-    display.completion_rate =
-        stats.total_games > 0 ? static_cast<double>(stats.total_completed) / stats.total_games * 100.0 : 0.0;
+    display.completion_rate = stats.total_games > 0 ? static_cast<double>(stats.total_completed) /
+                                                          static_cast<double>(stats.total_games) * 100.0
+                                                    : 0.0;
     display.current_streak = stats.current_win_streak;
     display.best_streak = stats.best_win_streak;
 
     // Calculate overall average from all difficulty levels (including Master at index 4)
     std::chrono::milliseconds total_average_time{0};
-    int total_completed_games = 0;
+    int64_t total_completed_games = 0;
     for (size_t i = 0; i < core::DIFFICULTY_COUNT; ++i) {
         if (stats.games_completed[i] > 0 && stats.average_times[i].count() > 0) {
             total_average_time += stats.average_times[i] * stats.games_completed[i];


### PR DESCRIPTION
Restores the nightly build to green. It was red since 2026-05-30 from two independent causes; this PR fixes both.

## Summary

**1. Whole-project clang-tidy (real code regression)** — 7 `narrowing-conversions` from widening the statistics counters to `int64_t` (#27, #28, #30) + 1 `bugprone-exception-escape` in `main()`. These slipped past the PR gate because it runs `clang-tidy-diff` (changed lines only); the nightly lints the whole project.
- Make the implicit `long→double` conversions explicit (`static_cast<double>`); widen the `total_completed_games` accumulator to `int64_t`. Behaviour is byte-identical.
- Wrap `main()`'s body in a top-level try/catch that logs via `spdlog::critical` and returns `EXIT_FAILURE` instead of `std::terminate`.

**2. Copy-Paste Detection job (infra)** — `Install Java` 404'd because `default-jre-headless` (→ `openjdk-21-jre-headless`) was fetched against a stale runner apt index. Add `sudo apt-get update` before the install, matching what `install-qt-deps` already does for the other apt jobs.

## Test plan

- [x] `cmake --build --preset relwithdebinfo` — clean, no `-Werror`
- [x] clang-tidy on all 4 changed files — 0 error-level findings (all 8 resolved)
- [x] `unit_tests` — 1071 cases / 15,711 assertions pass
- [x] `integration_tests` — 14 cases / 270 assertions pass
- [x] `./scripts/format.sh check` — pass
- [x] `nightly.yml` parses (yaml.safe_load)
- [ ] CI green; next nightly: whole-project clang-tidy + CPD job both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)