### PR TITLE
fix(windows): portable env helpers + writable fsync handle (#65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,11 +215,17 @@ jobs:
     # (a broken-test PR is exactly when lint feedback matters). format-check must
     # still gate it (a formatting violation skips this job). On a test-failure the
     # cache is restored via the restore-keys prefix instead of the exact SHA.
-    # Skip on pushes to main: there's no meaningful diff base (already merged).
-    # Nightly's full clang-tidy is the safety net for the trunk.
+    # Also runs on manual workflow_dispatch so a full-matrix dispatch (which
+    # otherwise cancels the in-flight PR run via the shared concurrency group)
+    # still covers lint. Skip on main for push/dispatch: there's no meaningful
+    # diff base (already merged), so the diff is empty and the pass is vacuous.
+    # PR events are never on refs/heads/main (their ref is refs/pull/N/merge),
+    # so the guard leaves them unaffected. Nightly's full clang-tidy is the
+    # safety net for the trunk.
     if: |
       always() && needs.format-check.result == 'success' &&
-      (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main'))
+      (github.event_name == 'pull_request' ||
+       ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref != 'refs/heads/main'))
     timeout-minutes: 25
 
     steps:

--- a/src/core/file_utils.cpp
+++ b/src/core/file_utils.cpp
@@ -42,7 +42,10 @@ namespace {
 // rename metadata can reach disk before the data, defeating the atomicity.
 [[nodiscard]] std::error_code fsyncFile(const std::filesystem::path& path) {
 #ifdef _WIN32
-    const int fd = ::_open(path.string().c_str(), _O_RDONLY | _O_BINARY);
+    // _commit() flushes via FlushFileBuffers, which requires a handle with
+    // GENERIC_WRITE access. Opening read-only yields ERROR_ACCESS_DENIED,
+    // surfaced as EBADF — so the descriptor must be writable here.
+    const int fd = ::_open(path.string().c_str(), _O_WRONLY | _O_BINARY);
     if (fd == -1) {
         return {errno, std::generic_category()};
     }

--- a/tests/helpers/test_utils.cpp
+++ b/tests/helpers/test_utils.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 
 namespace sudoku::test {
 
@@ -43,6 +44,26 @@ TempTestDir::~TempTestDir() {
 
 const std::filesystem::path& TempTestDir::path() const {
     return path_;
+}
+
+// ============================================================================
+// Portable Environment Variable Helpers
+// ============================================================================
+
+void setEnvVar(const char* name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name, value.c_str());
+#else
+    ::setenv(name, value.c_str(), 1);
+#endif
+}
+
+void unsetEnvVar(const char* name) {
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    ::unsetenv(name);
+#endif
 }
 
 // ============================================================================

--- a/tests/helpers/test_utils.cpp
+++ b/tests/helpers/test_utils.cpp
@@ -66,6 +66,22 @@ void unsetEnvVar(const char* name) {
 #endif
 }
 
+ScopedEnvVar::ScopedEnvVar(const char* name, const std::string& value) : name_(name) {
+    if (const char* prev = std::getenv(name)) {
+        previous_ = prev;
+        had_previous_ = true;
+    }
+    setEnvVar(name, value);
+}
+
+ScopedEnvVar::~ScopedEnvVar() {
+    if (had_previous_) {
+        setEnvVar(name_, previous_);
+    } else {
+        unsetEnvVar(name_);
+    }
+}
+
 // ============================================================================
 // Board Search Helpers
 // ============================================================================

--- a/tests/helpers/test_utils.h
+++ b/tests/helpers/test_utils.h
@@ -54,6 +54,20 @@ private:
 };
 
 // ============================================================================
+// Portable Environment Variable Helpers
+// ============================================================================
+
+/// Set an environment variable for the current process.
+/// POSIX `setenv`/`unsetenv` are unavailable in the MSVC CRT, so this wraps
+/// `_putenv_s` on Windows and `setenv` elsewhere. Overwrites any existing value.
+void setEnvVar(const char* name, const std::string& value);
+
+/// Remove an environment variable from the current process.
+/// Wraps `_putenv_s(name, "")` on Windows (an empty value deletes the entry)
+/// and `unsetenv` elsewhere.
+void unsetEnvVar(const char* name);
+
+// ============================================================================
 // Board Search Helpers (Replace goto patterns)
 // ============================================================================
 

--- a/tests/helpers/test_utils.h
+++ b/tests/helpers/test_utils.h
@@ -67,6 +67,26 @@ void setEnvVar(const char* name, const std::string& value);
 /// and `unsetenv` elsewhere.
 void unsetEnvVar(const char* name);
 
+/// RAII override of an environment variable: sets `name` to `value` on
+/// construction and restores the previous value — or unsets it if it was
+/// absent — on destruction. Built on the portable setEnvVar/unsetEnvVar
+/// helpers, so it works on MSVC and POSIX alike.
+class ScopedEnvVar {
+public:
+    ScopedEnvVar(const char* name, const std::string& value);
+    ~ScopedEnvVar();
+
+    ScopedEnvVar(const ScopedEnvVar&) = delete;
+    ScopedEnvVar& operator=(const ScopedEnvVar&) = delete;
+    ScopedEnvVar(ScopedEnvVar&&) = delete;
+    ScopedEnvVar& operator=(ScopedEnvVar&&) = delete;
+
+private:
+    const char* name_;
+    std::string previous_;
+    bool had_previous_{false};
+};
+
 // ============================================================================
 // Board Search Helpers (Replace goto patterns)
 // ============================================================================

--- a/tests/unit/test_game_view_model_state_coverage.cpp
+++ b/tests/unit/test_game_view_model_state_coverage.cpp
@@ -17,6 +17,8 @@
 #include "../helpers/game_view_model_fixture.h"
 #include "../helpers/test_utils.h"
 
+#include "infrastructure/app_directory_manager.h"
+
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -190,36 +192,51 @@ TEST_CASE("GameViewModel CSV/JSON export entry points", "[game_view_model][state
     fixture.view_model->startNewGame(Difficulty::Easy);
 
     // The default-directory export functions (exportAggregateStatsCsv / exportGameSessionsCsv)
-    // resolve their output path via AppDirectoryManager::getDefaultDirectory, which honors
-    // XDG_DATA_HOME on Linux. Redirect it to the fixture's temp dir so the test stays
-    // hermetic and doesn't pollute the user's real ~/.local/share/sudoku/.
-    struct XdgOverride {
+    // resolve their output path via AppDirectoryManager::getDefaultDirectory. That base
+    // directory is derived from a different environment variable on each platform
+    // (XDG_DATA_HOME on Linux, HOME on macOS, APPDATA on Windows — see
+    // AppDirectoryManager::getPlatformBaseDirectory). Redirect whichever one applies to
+    // the fixture's temp dir so the test stays hermetic and doesn't pollute the user's
+    // real data directory.
+#if defined(_WIN32)
+    constexpr const char* kDataDirEnv = "APPDATA";
+#elif defined(__APPLE__)
+    constexpr const char* kDataDirEnv = "HOME";
+#else
+    constexpr const char* kDataDirEnv = "XDG_DATA_HOME";
+#endif
+    struct DataDirOverride {
+        const char* name;
         std::string previous;
         bool had_previous{false};
-        explicit XdgOverride(const std::string& path) {
-            if (const char* prev = std::getenv("XDG_DATA_HOME")) {
+        DataDirOverride(const char* env_name, const std::string& path) : name(env_name) {
+            if (const char* prev = std::getenv(env_name)) {
                 previous = prev;
                 had_previous = true;
             }
-            ::setenv("XDG_DATA_HOME", path.c_str(), 1);
+            sudoku::test::setEnvVar(env_name, path);
         }
-        XdgOverride(const XdgOverride&) = delete;
-        XdgOverride& operator=(const XdgOverride&) = delete;
-        XdgOverride(XdgOverride&&) = delete;
-        XdgOverride& operator=(XdgOverride&&) = delete;
-        ~XdgOverride() {
+        DataDirOverride(const DataDirOverride&) = delete;
+        DataDirOverride& operator=(const DataDirOverride&) = delete;
+        DataDirOverride(DataDirOverride&&) = delete;
+        DataDirOverride& operator=(DataDirOverride&&) = delete;
+        ~DataDirOverride() {
             if (had_previous) {
-                ::setenv("XDG_DATA_HOME", previous.c_str(), 1);
+                sudoku::test::setEnvVar(name, previous);
             } else {
-                ::unsetenv("XDG_DATA_HOME");
+                sudoku::test::unsetEnvVar(name);
             }
         }
     };
-    XdgOverride xdg(fixture.temp_dir.path().string());
+    DataDirOverride data_dir(kDataDirEnv, fixture.temp_dir.path().string());
 
-    // The serializer does not auto-create parent directories — pre-create the
-    // path that AppDirectoryManager will resolve to under the redirected XDG_DATA_HOME.
-    std::filesystem::create_directories(fixture.temp_dir.path() / "sudoku" / "stats");
+    // The serializer does not auto-create parent directories — pre-create the path that
+    // AppDirectoryManager now resolves to under the redirected base directory. Querying
+    // getDefaultDirectory (rather than hardcoding the layout) keeps this correct across
+    // platforms, whose base-directory layouts differ.
+    std::filesystem::create_directories(
+        infrastructure::AppDirectoryManager::getDefaultDirectory(
+            infrastructure::DirectoryType::Statistics));
 
     SECTION("exportAggregateStatsCsv writes a CSV under the redirected XDG path") {
         auto result = fixture.view_model->exportAggregateStatsCsv();

--- a/tests/unit/test_game_view_model_state_coverage.cpp
+++ b/tests/unit/test_game_view_model_state_coverage.cpp
@@ -204,30 +204,7 @@ TEST_CASE("GameViewModel CSV/JSON export entry points", "[game_view_model][state
 #else
     constexpr const char* kDataDirEnv = "XDG_DATA_HOME";
 #endif
-    struct DataDirOverride {
-        const char* name;
-        std::string previous;
-        bool had_previous{false};
-        DataDirOverride(const char* env_name, const std::string& path) : name(env_name) {
-            if (const char* prev = std::getenv(env_name)) {
-                previous = prev;
-                had_previous = true;
-            }
-            sudoku::test::setEnvVar(env_name, path);
-        }
-        DataDirOverride(const DataDirOverride&) = delete;
-        DataDirOverride& operator=(const DataDirOverride&) = delete;
-        DataDirOverride(DataDirOverride&&) = delete;
-        DataDirOverride& operator=(DataDirOverride&&) = delete;
-        ~DataDirOverride() {
-            if (had_previous) {
-                sudoku::test::setEnvVar(name, previous);
-            } else {
-                sudoku::test::unsetEnvVar(name);
-            }
-        }
-    };
-    DataDirOverride data_dir(kDataDirEnv, fixture.temp_dir.path().string());
+    sudoku::test::ScopedEnvVar data_dir(kDataDirEnv, fixture.temp_dir.path().string());
 
     // The serializer does not auto-create parent directories — pre-create the path that
     // AppDirectoryManager now resolves to under the redirected base directory. Querying

--- a/tests/unit/test_game_view_model_state_coverage.cpp
+++ b/tests/unit/test_game_view_model_state_coverage.cpp
@@ -16,7 +16,6 @@
 
 #include "../helpers/game_view_model_fixture.h"
 #include "../helpers/test_utils.h"
-
 #include "infrastructure/app_directory_manager.h"
 
 #include <chrono>
@@ -235,8 +234,7 @@ TEST_CASE("GameViewModel CSV/JSON export entry points", "[game_view_model][state
     // getDefaultDirectory (rather than hardcoding the layout) keeps this correct across
     // platforms, whose base-directory layouts differ.
     std::filesystem::create_directories(
-        infrastructure::AppDirectoryManager::getDefaultDirectory(
-            infrastructure::DirectoryType::Statistics));
+        infrastructure::AppDirectoryManager::getDefaultDirectory(infrastructure::DirectoryType::Statistics));
 
     SECTION("exportAggregateStatsCsv writes a CSV under the redirected XDG path") {
         auto result = fixture.view_model->exportAggregateStatsCsv();


### PR DESCRIPTION
Fixes #65.

## Summary
Two MSVC-only defects kept the `build-windows` job red. The first is the one reported in #65; the second was found while verifying the fix locally on MSVC.

1. **Compile error (#65).** `tests/unit/test_game_view_model_state_coverage.cpp` used POSIX `::setenv`/`::unsetenv` in its `XdgOverride` RAII helper. MSVC's CRT does not provide these → `C3861: identifier not found`, so `unit_tests` failed to compile.

2. **Latent test failure (found while verifying).** Once compiling, the export test still failed: `file_utils::fsyncFile` opened the temp file `_O_RDONLY` before `_commit()`. On Windows `_commit` flushes via `FlushFileBuffers`, which requires a `GENERIC_WRITE` handle; a read-only handle returns `ERROR_ACCESS_DENIED`, surfaced as `EBADF` ("bad file descriptor"), so **every** atomic write failed. This was latent only because the compile error in (1) meant the Windows tests never ran. Without this fix, the Windows job would still be red after the compile fix.

## Changes
- Add portable `setEnvVar`/`unsetEnvVar` helpers in `tests/helpers/test_utils` (`_putenv_s` on Windows, `setenv`/`unsetenv` elsewhere).
- Make the export test hermetic on **all** platforms: redirect the platform-appropriate base-dir env var (`APPDATA` / `HOME` / `XDG_DATA_HOME`) — not just `XDG_DATA_HOME` — and pre-create the path that `AppDirectoryManager::getDefaultDirectory` actually resolves to, rather than hardcoding the Linux layout. (A naive port of just the `setenv` call would compile but leave the two CSV sections non-hermetic/failing on Windows, since Windows reads `APPDATA`, not `XDG_DATA_HOME`.)
- Open the fsync handle `_O_WRONLY` on Windows so `_commit` succeeds.

## Verification
Built and ran locally on MSVC (VS BuildTools 18, Qt 6.10.2, Ninja):
- `unit_tests` builds clean (previously `C3861`).
- Full unit suite: **1068 passed / 3 skipped, 15691 assertions passed**.

## Notes
- CI gating left as-is per discussion (`build-windows`/`build-macos` remain `workflow_dispatch`-only). Acceptance item 3 (run cross-platform builds per-push) is **not** addressed here and can be a follow-up.
- A Windows `workflow_dispatch` CI run will be triggered against this branch to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)