### PR TITLE
feat(input): keyboard modifier overrides for value/pencil/color entry (0a.2)

### DIFF
--- a/src/core/training_types.h
+++ b/src/core/training_types.h
@@ -50,6 +50,12 @@ enum class AnswerResult : uint8_t {
     Incorrect          ///< Wrong answer
 };
 
+/// Training exposes exactly two player palette colors (A and B); 0 means "no color".
+/// These bound the valid `player_color` range so out-of-range input (e.g. a keyboard
+/// Alt+digit chord on the shared board widget) cannot write an unrenderable color value.
+inline constexpr int kMinPlayerColor = 1;  ///< Color A
+inline constexpr int kMaxPlayerColor = 2;  ///< Color B
+
 /// State of a single cell in a training exercise board
 struct TrainingCellState {
     int value{0};                                ///< Placed value (0 = empty)

--- a/src/view/key_utils.cpp
+++ b/src/view/key_utils.cpp
@@ -24,7 +24,7 @@ namespace {
 /// not a digit-row key. Used only to recover Shift+digit, where the layout-cooked key() is a
 /// glyph (e.g. Key_Exclam on US) but the physical key is stable per platform.
 [[nodiscard]] int nativeDigitRow(quint32 native_virtual_key) {
-#if defined(Q_OS_MACOS)
+#ifdef Q_OS_MACOS
     // Carbon kVK_ANSI_* virtual key codes (what the cocoa backend reports).
     switch (native_virtual_key) {
         case 0x12:

--- a/src/view/key_utils.cpp
+++ b/src/view/key_utils.cpp
@@ -1,0 +1,95 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "key_utils.h"
+
+namespace sudoku::view {
+
+namespace {
+
+/// Map a platform native virtual key on the digit row to its digit (1..9), or 0 if the key is
+/// not a digit-row key. Used only to recover Shift+digit, where the layout-cooked key() is a
+/// glyph (e.g. Key_Exclam on US) but the physical key is stable per platform.
+[[nodiscard]] int nativeDigitRow(quint32 native_virtual_key) {
+#if defined(Q_OS_MACOS)
+    // Carbon kVK_ANSI_* virtual key codes (what the cocoa backend reports).
+    switch (native_virtual_key) {
+        case 0x12:
+            return 1;
+        case 0x13:
+            return 2;
+        case 0x14:
+            return 3;
+        case 0x15:
+            return 4;
+        case 0x17:
+            return 5;
+        case 0x16:
+            return 6;
+        case 0x1A:
+            return 7;
+        case 0x1C:
+            return 8;
+        case 0x19:
+            return 9;
+        default:
+            return 0;
+    }
+#else
+    // Windows VK codes ('1'..'9' == 0x31..0x39) and X11 keysyms (XK_1..XK_9 == 0x31..0x39)
+    // both coincide with the ASCII digits.
+    if (native_virtual_key >= 0x31 && native_virtual_key <= 0x39) {
+        return static_cast<int>(native_virtual_key) - 0x30;
+    }
+    return 0;
+#endif
+}
+
+}  // namespace
+
+std::optional<int> resolveDigit(int key, Qt::KeyboardModifiers modifiers, quint32 native_virtual_key) {
+    // Primary path: Qt::Key_1..Key_9 survive intact for plain digits, Ctrl+digit, Alt+digit,
+    // numpad digits, AND synthesized Shift+digit (QTest sends Key_1 + Shift, not the cooked
+    // glyph). This layout-stable core is the only path most callers ever exercise.
+    if (key >= Qt::Key_1 && key <= Qt::Key_9) {
+        return key - Qt::Key_1 + 1;
+    }
+    // Shift on a physical keyboard cooks the digit into a layout glyph; recover it from the
+    // native (physical) key. Only Shift remaps the key, so this is the sole case that needs it.
+    if (modifiers.testFlag(Qt::ShiftModifier)) {
+        if (const int digit = nativeDigitRow(native_virtual_key); digit != 0) {
+            return digit;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<viewmodel::InputMode> overrideLayerFor(Qt::KeyboardModifiers modifiers) {
+    // On macOS Qt maps Cmd→ControlModifier and Option→AltModifier, so the same checks cover
+    // both platforms' "value / pencil / color" chords.
+    if (modifiers.testFlag(Qt::ControlModifier)) {
+        return viewmodel::InputMode::Normal;  // value
+    }
+    if (modifiers.testFlag(Qt::ShiftModifier)) {
+        return viewmodel::InputMode::Notes;  // pencil
+    }
+    if (modifiers.testFlag(Qt::AltModifier)) {
+        return viewmodel::InputMode::Color;  // color
+    }
+    return std::nullopt;
+}
+
+}  // namespace sudoku::view

--- a/src/view/key_utils.h
+++ b/src/view/key_utils.h
@@ -1,0 +1,44 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "view_model/game_view_model.h"  // viewmodel::InputMode
+
+#include <optional>
+
+#include <QtGlobal>
+#include <qnamespace.h>
+
+namespace sudoku::view {
+
+/// Resolve a board digit (1..9) from a key event in a layout- and platform-robust way.
+///
+/// `key` is QKeyEvent::key(), `modifiers` is QKeyEvent::modifiers(), and
+/// `native_virtual_key` is QKeyEvent::nativeVirtualKey(). The helper is pure so it can be
+/// unit-tested directly without synthesizing native key events (which QTest cannot do).
+///
+/// Returns std::nullopt for non-digit keys — including `0`, which is the erase key handled
+/// separately, not a placement digit.
+[[nodiscard]] std::optional<int> resolveDigit(int key, Qt::KeyboardModifiers modifiers, quint32 native_virtual_key);
+
+/// Map modifier flags to the layer a modified digit targets: Ctrl/Cmd → value (Normal),
+/// Shift → pencil (Notes), Alt/Option → color (Color). std::nullopt means "no override —
+/// act on the active input mode". Non-layer modifiers (e.g. KeypadModifier) are ignored, so
+/// numpad digits still act on the active mode.
+[[nodiscard]] std::optional<viewmodel::InputMode> overrideLayerFor(Qt::KeyboardModifiers modifiers);
+
+}  // namespace sudoku::view

--- a/src/view/main_window.cpp
+++ b/src/view/main_window.cpp
@@ -22,6 +22,7 @@
 #include "core/locale_utils.h"
 #include "core/observable.h"
 #include "infrastructure/app_directory_manager.h"
+#include "key_utils.h"
 #include "locale_utils.h"
 #include "model/game_state.h"
 #include "puzzle_import_dialog.h"
@@ -267,10 +268,12 @@ void MainWindow::setupCentralWidget() {
 
     connect(training_widget_, &TrainingWidget::backToGame, this, [this]() { central_stack_->setCurrentIndex(0); });
 
-    connect(board_widget_, &SudokuBoardWidget::numberKeyPressed, this, [this](int number) {
+    connect(board_widget_, &SudokuBoardWidget::digitKeyPressed, this, [this](int digit, Qt::KeyboardModifiers mods) {
         auto pos_opt = board_widget_->selectedCell();
         if (view_model_ && pos_opt.has_value()) {
-            view_model_->handleNumberInput(pos_opt.value(), number);
+            // overrideLayerFor maps Ctrl/Shift/Alt → the forced layer; std::nullopt keeps the
+            // active mode (AC-1). The ViewModel owns the actual routing decision (AC-8).
+            view_model_->handleNumberInput(pos_opt.value(), digit, overrideLayerFor(mods));
         }
     });
 }
@@ -758,35 +761,48 @@ void MainWindow::keyPressEvent(QKeyEvent* event) {
         return;
     }
 
-    // N key toggles Notes mode directly
-    if (key == Qt::Key_N && event->modifiers() == Qt::NoModifier) {
-        auto current = view_model_->getInputMode();
-        view_model_->setInputMode(current == viewmodel::InputMode::Notes ? viewmodel::InputMode::Normal
-                                                                         : viewmodel::InputMode::Notes);
-        updateButtonPanel();
-        return;
-    }
+    // Number keys 1-9 (with Ctrl/Shift/Alt overrides) are handled by the board widget signal
+    // (digitKeyPressed). The hardcoded 'N' jump-to-Notes key was retired in 0a.2 — Space-cycle
+    // reaches any mode and the gameplay layer stays language-neutral.
 
-    // Number keys 1-9 are handled by board widget signals (numberKeyPressed)
-
-    // Editing keys
+    // Editing keys. Plain Delete/Backspace/0 clears the active layer; modifier combos clear a
+    // specific layer in any mode: Ctrl+0/Delete → value, Alt+0/Delete → color, Shift+Delete →
+    // all pencil marks. 0 is the erase digit in this domain, so Ctrl+0/Alt+0 arrive as Key_0.
     if (key == Qt::Key_Delete || key == Qt::Key_Backspace || key == Qt::Key_0) {
         auto edit_pos = board_widget_->selectedCell();
-        if (edit_pos.has_value()) {
-            switch (view_model_->getInputMode()) {
-                case viewmodel::InputMode::Color:
-                    view_model_->colorCell(edit_pos.value(), 0);  // Clear color
-                    break;
-                case viewmodel::InputMode::EditGivens:
-                    // clearCell is blocked on given cells; edit-mode givens need
-                    // their own clear path.
-                    view_model_->setEditModeGiven(edit_pos.value(), 0);
-                    break;
-                case viewmodel::InputMode::Normal:
-                case viewmodel::InputMode::Notes:
-                    view_model_->clearCell(edit_pos.value());
-                    break;
+        if (!edit_pos.has_value()) {
+            return;
+        }
+        const auto pos = edit_pos.value();
+        const auto mode = view_model_->getInputMode();
+        const auto mods = event->modifiers();
+
+        // Modifier erase overrides are meaningless while building givens (AC-9).
+        const bool has_erase_modifier =
+            mods.testFlag(Qt::ControlModifier) || mods.testFlag(Qt::AltModifier) || mods.testFlag(Qt::ShiftModifier);
+        if (mode != viewmodel::InputMode::EditGivens && has_erase_modifier) {
+            if (mods.testFlag(Qt::ControlModifier)) {
+                view_model_->clearCell(pos);  // Ctrl+0 / Ctrl+Delete → clear the value
+            } else if (mods.testFlag(Qt::AltModifier)) {
+                view_model_->colorCell(pos, 0);  // Alt+0 / Alt+Delete → clear the color
+            } else if (key != Qt::Key_0) {
+                view_model_->clearCellNotes(pos);  // Shift+Delete → clear all pencil marks
             }
+            return;
+        }
+
+        switch (mode) {
+            case viewmodel::InputMode::Color:
+                view_model_->colorCell(pos, 0);  // Clear color
+                break;
+            case viewmodel::InputMode::EditGivens:
+                // clearCell is blocked on given cells; edit-mode givens need their own clear path.
+                view_model_->setEditModeGiven(pos, 0);
+                break;
+            case viewmodel::InputMode::Normal:
+            case viewmodel::InputMode::Notes:
+                view_model_->clearCell(pos);
+                break;
         }
         return;
     }

--- a/src/view/sudoku_board_widget.cpp
+++ b/src/view/sudoku_board_widget.cpp
@@ -18,6 +18,7 @@
 
 #include "core/constants.h"
 #include "core/i18n_helpers.h"
+#include "key_utils.h"
 
 #include <array>
 #include <optional>
@@ -166,19 +167,12 @@ void SudokuBoardWidget::keyPressEvent(QKeyEvent* event) {
         return;
     }
 
-    // Number keys 1-9
-    if (key >= Qt::Key_1 && key <= Qt::Key_9) {
-        emit numberKeyPressed(key - Qt::Key_1 + 1);
-        return;
-    }
-
-    // Color keys A/B
-    if (key == Qt::Key_A) {
-        emit colorKeyPressed(1);
-        return;
-    }
-    if (key == Qt::Key_B) {
-        emit colorKeyPressed(2);
+    // Board digits 1-9, with optional Ctrl/Shift/Alt overrides. resolveDigit is the single,
+    // layout- and shift-glyph-aware resolution point, so a modified digit never leaks to the
+    // MainWindow bubble path. The raw modifiers travel with the signal; the consumer decides
+    // their meaning. 0 / Delete / Backspace / Space are deliberately left to bubble up.
+    if (auto digit = resolveDigit(key, event->modifiers(), event->nativeVirtualKey()); digit.has_value()) {
+        emit digitKeyPressed(digit.value(), event->modifiers());
         return;
     }
 

--- a/src/view/sudoku_board_widget.h
+++ b/src/view/sudoku_board_widget.h
@@ -25,6 +25,7 @@
 
 #include <QWidget>
 #include <qcolor.h>
+#include <qnamespace.h>
 #include <qpoint.h>
 #include <qrect.h>
 #include <qtmetamacros.h>
@@ -80,8 +81,11 @@ public:
 
 signals:
     void cellClicked(size_t row, size_t col);
-    void numberKeyPressed(int value);
-    void colorKeyPressed(int color);
+    /// A board digit (1..9) was entered. `modifiers` carries the raw Ctrl/Shift/Alt flags so
+    /// each consumer (the game vs Training) decides the meaning — this keeps the game's override
+    /// semantics out of the shared widget. The digit is already resolved (layout/shift-glyph
+    /// aware) via resolveDigit; `0`, Delete and Space are not reported here (they bubble up).
+    void digitKeyPressed(int digit, Qt::KeyboardModifiers modifiers);
 
 protected:
     void paintEvent(QPaintEvent* event) override;

--- a/src/view/training_widget.cpp
+++ b/src/view/training_widget.cpp
@@ -504,19 +504,17 @@ void TrainingWidget::buildExercisePage() {
         }
     });
 
-    // Keyboard number keys from board → ViewModel
-    connect(training_board_, &SudokuBoardWidget::numberKeyPressed, this, [this](int value) {
+    // Keyboard digit input from the shared board → ViewModel. The widget now reports a single
+    // raw intent (resolved digit + modifier flags); Training applies its own meaning: Alt+digit
+    // colors the cell (migrated from the retired A/B keys), any other digit places/eliminates.
+    // The game-only Ctrl (value) and Shift (pencil) overrides are intentionally not honored here.
+    connect(training_board_, &SudokuBoardWidget::digitKeyPressed, this, [this](int digit, Qt::KeyboardModifiers mods) {
         if (training_vm_) {
-            training_vm_->applyNumber(value);
-            undo_btn_->setEnabled(training_vm_->canUndo());
-            redo_btn_->setEnabled(training_vm_->canRedo());
-        }
-    });
-
-    // Keyboard color keys from board → ViewModel
-    connect(training_board_, &SudokuBoardWidget::colorKeyPressed, this, [this](int color) {
-        if (training_vm_) {
-            training_vm_->applyColor(color);
+            if (mods.testFlag(Qt::AltModifier)) {
+                training_vm_->applyColor(digit);
+            } else {
+                training_vm_->applyNumber(digit);
+            }
             undo_btn_->setEnabled(training_vm_->canUndo());
             redo_btn_->setEnabled(training_vm_->canRedo());
         }

--- a/src/view_model/game_view_model.h
+++ b/src/view_model/game_view_model.h
@@ -58,6 +58,10 @@ enum class InputMode : std::uint8_t {
     EditGivens,  ///< Number keys lay down "given" clue cells for an imported puzzle (I-2)
 };
 
+/// Size of the free-form analysis color palette (valid colors are 1..kColorPaletteSize).
+/// A domain value, not board geometry — there are six palette entries (see SudokuBoardColors).
+inline constexpr int kColorPaletteSize = 6;
+
 /// Commands that can be executed from the UI
 enum class GameCommand : std::uint8_t {
     NewGame,
@@ -205,8 +209,17 @@ public:
     void enterNote(const core::Position& pos, int number);
     void clearCell(const core::Position& pos);
 
-    /// Mode-aware number input: validates and routes to enterNumber/enterNote/colorCell
-    void handleNumberInput(const core::Position& pos, int number);
+    /// Clear every pencil mark in a single cell (the Shift+Delete shortcut). Reuses the
+    /// undoable note-removal path; no-op on given or filled cells, since pencil marks only
+    /// ever exist on empty cells.
+    void clearCellNotes(const core::Position& pos);
+
+    /// Mode-aware number input: validates and routes to enterNumber/enterNote/colorCell.
+    /// `override_layer` forces a specific layer regardless of the active InputMode
+    /// (Ctrl→Normal/value, Shift→Notes/pencil, Alt→Color); std::nullopt uses the active
+    /// mode (the regression-safe default). Overrides are no-ops in EditGivens.
+    void handleNumberInput(const core::Position& pos, int number,
+                           std::optional<InputMode> override_layer = std::nullopt);
 
     // Analysis cell coloring (ephemeral, not saved/undoable)
     void colorCell(const core::Position& pos, uint8_t color_index);

--- a/src/view_model/game_view_model_board.cpp
+++ b/src/view_model/game_view_model_board.cpp
@@ -219,8 +219,27 @@ void GameViewModel::colorCell(const core::Position& pos, uint8_t color_index) {
         [&pos, color_index](model::GameState& state) { state.setCellColor(pos.row, pos.col, color_index); });
 }
 
-void GameViewModel::handleNumberInput(const core::Position& pos, int number) {
-    if (!isGameActive() || number < 1 || number > 9) {
+void GameViewModel::clearCellNotes(const core::Position& pos) {
+    if (!isGameActive()) {
+        return;
+    }
+    const auto& state = gameState.get();
+    // Pencil marks only ever exist on empty, non-given cells.
+    if (state.isGiven(pos) || state.getValue(pos) != core::EMPTY_CELL) {
+        return;
+    }
+    // Toggle each present mark off through the existing undoable note path — no parallel
+    // note-clearing logic (AC-13). Snapshot first: enterNote mutates the live state.
+    const auto notes = state.getNotes(pos);
+    for (int value = core::MIN_VALUE; value <= core::MAX_VALUE; ++value) {
+        if (notes.contains(value)) {
+            enterNote(pos, value);
+        }
+    }
+}
+
+void GameViewModel::handleNumberInput(const core::Position& pos, int number, std::optional<InputMode> override_layer) {
+    if (!isGameActive() || number < core::MIN_VALUE || number > core::MAX_VALUE) {
         return;
     }
     const auto& state = gameState.get();
@@ -232,6 +251,10 @@ void GameViewModel::handleNumberInput(const core::Position& pos, int number) {
     // EditGivens is the one mode where "given" cells are still editable — the user is
     // building the puzzle, not solving it. Handle it before the is_given guard.
     if (getInputMode() == InputMode::EditGivens) {
+        // While laying down givens the *override* is meaningless, not the keystroke: a held
+        // modifier is stripped and the key acts as its plain self (Ctrl+8/Alt+8 → set given 8),
+        // matching the already-plain Ctrl+Delete given-clear. Only final givens exist here, so
+        // there is no value/pencil/color layer to force (AC-9; UX ruling 2026-06-04).
         // Tapping a digit on a cell already showing that digit clears it (toggle behaviour
         // parallel to Normal mode's cell.value == number → clear).
         const int new_value = (cell.value == number) ? 0 : number;
@@ -243,8 +266,14 @@ void GameViewModel::handleNumberInput(const core::Position& pos, int number) {
         return;
     }
 
-    switch (getInputMode()) {
+    // No override → act on the active mode (regression-safe, AC-1). An override forces its
+    // layer (Ctrl→Normal/value, Shift→Notes/pencil, Alt→Color) in any mode.
+    const InputMode layer = override_layer.value_or(getInputMode());
+
+    switch (layer) {
         case InputMode::Normal:
+            // Value layer: place into an empty cell, or clear when re-pressing the same value.
+            // Reused verbatim by the Ctrl override (AC-2, AC-13).
             if (cell.value == 0) {
                 enterNumber(pos, number);
             } else if (cell.value == number) {
@@ -252,17 +281,27 @@ void GameViewModel::handleNumberInput(const core::Position& pos, int number) {
             }
             break;
         case InputMode::Notes:
+            // enterNote already toggles and honors the empty-cell guard (AC-3, AC-13).
             if (cell.value == 0) {
                 enterNote(pos, number);
             }
             break;
         case InputMode::Color:
-            if (number <= 6) {
-                colorCell(pos, static_cast<uint8_t>(number));
+            if (number <= kColorPaletteSize) {
+                if (override_layer.has_value()) {
+                    // Alt override toggles off when re-applying the same color, and replaces
+                    // otherwise (AC-4). Plain Color mode keeps its set-only behavior (AC-1).
+                    const auto current = state.getCellColor(pos.row, pos.col);
+                    const auto target =
+                        (current == static_cast<uint8_t>(number)) ? uint8_t{0} : static_cast<uint8_t>(number);
+                    colorCell(pos, target);
+                } else {
+                    colorCell(pos, static_cast<uint8_t>(number));
+                }
             }
             break;
         case InputMode::EditGivens:
-            // Handled above.
+            // Unreachable: active EditGivens is handled above, and an override is never EditGivens.
             break;
     }
 }

--- a/src/view_model/training_view_model.cpp
+++ b/src/view_model/training_view_model.cpp
@@ -328,6 +328,12 @@ void TrainingViewModel::applyNumber(int value) {
 }
 
 void TrainingViewModel::applyColor(int color) {
+    // Training has exactly two palette colors (A=1, B=2). Reject anything outside that range so a
+    // keyboard Alt+digit chord (the shared board widget resolves digits 1..9) cannot write an
+    // unrenderable player_color (3..9) — invisible, yet non-zero and recorded in undo history.
+    if (color < kMinPlayerColor || color > kMaxPlayerColor) {
+        return;
+    }
     const auto& state = trainingState.get();
     if (!state.selected_cell.has_value()) {
         return;

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -4,6 +4,7 @@ set(UI_TEST_SOURCES
     test_main_window_construction.cpp
     test_board_interaction.cpp
     test_keyboard_handling.cpp
+    test_resolve_digit.cpp
     test_menu_toolbar_actions.cpp
     test_view_model_binding.cpp
     test_training_widget.cpp

--- a/tests/ui/test_keyboard_handling.cpp
+++ b/tests/ui/test_keyboard_handling.cpp
@@ -45,8 +45,11 @@ private:
         return ctx_->game_vm->gameState.get().getCellColor(pos.row, pos.col);
     }
 
-    void selectEmptyCell();
-    [[nodiscard]] std::optional<core::Position> findGivenCell() const;
+    // Select the first empty cell and return it. Fails the test (and returns a default) if the
+    // board has none — returning a concrete Position keeps the call sites free of optional
+    // dereferences that clang-tidy's unchecked-optional-access cannot prove safe past QVERIFY.
+    core::Position selectEmptyCell();
+    [[nodiscard]] core::Position givenCellOrFail() const;
 };
 
 void TestKeyboardHandling::initTestCase() {
@@ -178,157 +181,144 @@ void TestKeyboardHandling::spaceKeyCyclesInputMode() {
 }
 
 void TestKeyboardHandling::ctrlDigitForcesValueWithToggleOff() {
-    selectEmptyCell();
-    auto pos = selectedPos();
-    QVERIFY(pos.has_value());
+    const auto pos = selectEmptyCell();
 
     // Force a final value while NOT in Normal mode — the override must win.
     ctx_->game_vm->setInputMode(viewmodel::InputMode::Notes);
     QTest::keyClick(window_->board_widget_, Qt::Key_8, Qt::ControlModifier);
     QApplication::processEvents();
-    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 8);
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).value, 8);
 
     // Same digit again clears it (toggle-off).
     QTest::keyClick(window_->board_widget_, Qt::Key_8, Qt::ControlModifier);
     QApplication::processEvents();
-    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 0);
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).value, 0);
 
     ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
 }
 
 void TestKeyboardHandling::shiftDigitTogglesPencilAndGuardsFilledCell() {
-    selectEmptyCell();
-    auto pos = selectedPos();
-    QVERIFY(pos.has_value());
+    const auto pos = selectEmptyCell();
 
     // Shift forces a pencil mark while in Normal mode. QTest sends Key_4 + Shift
     // (no native cooking), exercising the resolveDigit fallback path.
     ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
     QTest::keyClick(window_->board_widget_, Qt::Key_4, Qt::ShiftModifier);
     QApplication::processEvents();
-    QVERIFY(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(4));
+    QVERIFY(ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).notes.contains(4));
 
     // Re-press removes the mark.
     QTest::keyClick(window_->board_widget_, Qt::Key_4, Qt::ShiftModifier);
     QApplication::processEvents();
-    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(4));
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).notes.contains(4));
 
     // Filled-cell guard: place a value, then Shift+digit is a no-op.
     QTest::keyClick(window_->board_widget_, Qt::Key_6);  // Normal mode places 6
     QApplication::processEvents();
-    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 6);
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).value, 6);
     QTest::keyClick(window_->board_widget_, Qt::Key_2, Qt::ShiftModifier);
     QApplication::processEvents();
-    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(2));
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).notes.contains(2));
 
     QTest::keyClick(window_->board_widget_, Qt::Key_Delete);  // cleanup
     QApplication::processEvents();
 }
 
 void TestKeyboardHandling::altDigitAppliesColorWithToggleOff() {
-    selectEmptyCell();
-    auto pos = selectedPos();
-    QVERIFY(pos.has_value());
+    const auto pos = selectEmptyCell();
 
     ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
 
     QTest::keyClick(window_->board_widget_, Qt::Key_3, Qt::AltModifier);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(3));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(3));
 
     // Different digit replaces the color.
     QTest::keyClick(window_->board_widget_, Qt::Key_5, Qt::AltModifier);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(5));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(5));
 
     // Same digit again removes it.
     QTest::keyClick(window_->board_widget_, Qt::Key_5, Qt::AltModifier);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(0));
 }
 
 void TestKeyboardHandling::colorModePlainDigitAppliesColor() {
-    selectEmptyCell();
-    auto pos = selectedPos();
-    QVERIFY(pos.has_value());
+    const auto pos = selectEmptyCell();
 
     // The previously-untested Color-mode application path: a plain digit in Color mode.
     ctx_->game_vm->setInputMode(viewmodel::InputMode::Color);
     QTest::keyClick(window_->board_widget_, Qt::Key_2);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(2));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(2));
 
     // Plain Color mode is set-only (AC-1): re-pressing the same digit must NOT toggle the color off
     // (toggle-off is exclusive to the Alt override). This guards the trickiest behavioural split.
     QTest::keyClick(window_->board_widget_, Qt::Key_2);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(2));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(2));
 
-    ctx_->game_vm->colorCell(*pos, 0);  // cleanup
+    ctx_->game_vm->colorCell(pos, 0);  // cleanup
     ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
 }
 
 void TestKeyboardHandling::altDigitSevenToNineIsNoOp() {
-    selectEmptyCell();
-    auto pos = selectedPos();
-    QVERIFY(pos.has_value());
+    const auto pos = selectEmptyCell();
 
     QTest::keyClick(window_->board_widget_, Qt::Key_7, Qt::AltModifier);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(0));
     QTest::keyClick(window_->board_widget_, Qt::Key_9, Qt::AltModifier);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(0));
 }
 
 void TestKeyboardHandling::eraseFamilyModifierCombos() {
-    selectEmptyCell();
-    auto pos = selectedPos();
-    QVERIFY(pos.has_value());
+    const auto pos = selectEmptyCell();
     ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
 
     // Ctrl+0 clears the value in any mode.
     QTest::keyClick(window_->board_widget_, Qt::Key_5);  // place a value
     QApplication::processEvents();
-    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 5);
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).value, 5);
     QTest::keyClick(window_->board_widget_, Qt::Key_0, Qt::ControlModifier);
     QApplication::processEvents();
-    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 0);
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).value, 0);
 
     // Alt+0 clears the color.
     QTest::keyClick(window_->board_widget_, Qt::Key_4, Qt::AltModifier);  // set color 4
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(4));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(4));
     QTest::keyClick(window_->board_widget_, Qt::Key_0, Qt::AltModifier);
     QApplication::processEvents();
-    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+    QCOMPARE(colorAt(pos), static_cast<uint8_t>(0));
 
     // Shift+Delete clears all pencil marks in the cell.
     QTest::keyClick(window_->board_widget_, Qt::Key_1, Qt::ShiftModifier);  // pencil 1
     QTest::keyClick(window_->board_widget_, Qt::Key_3, Qt::ShiftModifier);  // pencil 3
     QApplication::processEvents();
-    QVERIFY(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(1));
+    QVERIFY(ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).notes.contains(1));
     QTest::keyClick(window_->board_widget_, Qt::Key_Delete, Qt::ShiftModifier);
     QApplication::processEvents();
-    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(1));
-    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(3));
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).notes.contains(1));
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos.row, pos.col).notes.contains(3));
 }
 
 void TestKeyboardHandling::overrideOnGivenCellIsNoOp() {
-    auto given = findGivenCell();
-    QVERIFY(given.has_value());
-    window_->board_widget_->setSelectedCell(given.value());
+    const auto given = givenCellOrFail();
+    window_->board_widget_->setSelectedCell(given);
     QApplication::processEvents();
 
-    const int given_value = ctx_->game_vm->gameState.get().getCell(given->row, given->col).value;
+    const int given_value = ctx_->game_vm->gameState.get().getCell(given.row, given.col).value;
     QTest::keyClick(window_->board_widget_, Qt::Key_8, Qt::ControlModifier);
     QApplication::processEvents();
 
     // The given is untouched by the value override.
-    QCOMPARE(ctx_->game_vm->gameState.get().getCell(given->row, given->col).value, given_value);
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(given.row, given.col).value, given_value);
 }
 
-std::optional<core::Position> TestKeyboardHandling::findGivenCell() const {
+core::Position TestKeyboardHandling::givenCellOrFail() const {
     const auto& state = ctx_->game_vm->gameState.get();
     for (size_t r = 0; r < core::BOARD_SIZE; ++r) {
         for (size_t c = 0; c < core::BOARD_SIZE; ++c) {
@@ -337,22 +327,25 @@ std::optional<core::Position> TestKeyboardHandling::findGivenCell() const {
             }
         }
     }
-    return std::nullopt;
+    QTest::qFail("No given cell found on Easy board", __FILE__, __LINE__);
+    return core::Position{.row = 0, .col = 0};
 }
 
-void TestKeyboardHandling::selectEmptyCell() {
+core::Position TestKeyboardHandling::selectEmptyCell() {
     const auto& state = ctx_->game_vm->gameState.get();
-    for (size_t r = 0; r < 9; ++r) {
-        for (size_t c = 0; c < 9; ++c) {
+    for (size_t r = 0; r < core::BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < core::BOARD_SIZE; ++c) {
             const auto& cell = state.getCell(r, c);
             if (cell.value == 0 && !cell.is_given) {
-                window_->board_widget_->setSelectedCell(core::Position{.row = r, .col = c});
+                const core::Position pos{.row = r, .col = c};
+                window_->board_widget_->setSelectedCell(pos);
                 QApplication::processEvents();
-                return;
+                return pos;
             }
         }
     }
-    QFAIL("No empty cell found on Easy board");
+    QTest::qFail("No empty cell found on Easy board", __FILE__, __LINE__);
+    return core::Position{.row = 0, .col = 0};
 }
 
 QTEST_MAIN(TestKeyboardHandling)

--- a/tests/ui/test_keyboard_handling.cpp
+++ b/tests/ui/test_keyboard_handling.cpp
@@ -25,6 +25,13 @@ private slots:
     void normalModeNumberKeyPlacesValue();
     void notesModeNumberKeyTogglesNote();
     void spaceKeyCyclesInputMode();
+    void ctrlDigitForcesValueWithToggleOff();
+    void shiftDigitTogglesPencilAndGuardsFilledCell();
+    void altDigitAppliesColorWithToggleOff();
+    void colorModePlainDigitAppliesColor();
+    void altDigitSevenToNineIsNoOp();
+    void eraseFamilyModifierCombos();
+    void overrideOnGivenCellIsNoOp();
 
 private:
     std::unique_ptr<test::UITestContext> ctx_;
@@ -34,7 +41,12 @@ private:
         return window_->board_widget_->selectedCell();
     }
 
+    [[nodiscard]] uint8_t colorAt(const core::Position& pos) const {
+        return ctx_->game_vm->gameState.get().getCellColor(pos.row, pos.col);
+    }
+
     void selectEmptyCell();
+    [[nodiscard]] std::optional<core::Position> findGivenCell() const;
 };
 
 void TestKeyboardHandling::initTestCase() {
@@ -163,6 +175,169 @@ void TestKeyboardHandling::spaceKeyCyclesInputMode() {
     QTest::keyClick(window_->board_widget_, Qt::Key_Space);
     QApplication::processEvents();
     QCOMPARE(ctx_->game_vm->getInputMode(), viewmodel::InputMode::Normal);
+}
+
+void TestKeyboardHandling::ctrlDigitForcesValueWithToggleOff() {
+    selectEmptyCell();
+    auto pos = selectedPos();
+    QVERIFY(pos.has_value());
+
+    // Force a final value while NOT in Normal mode — the override must win.
+    ctx_->game_vm->setInputMode(viewmodel::InputMode::Notes);
+    QTest::keyClick(window_->board_widget_, Qt::Key_8, Qt::ControlModifier);
+    QApplication::processEvents();
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 8);
+
+    // Same digit again clears it (toggle-off).
+    QTest::keyClick(window_->board_widget_, Qt::Key_8, Qt::ControlModifier);
+    QApplication::processEvents();
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 0);
+
+    ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
+}
+
+void TestKeyboardHandling::shiftDigitTogglesPencilAndGuardsFilledCell() {
+    selectEmptyCell();
+    auto pos = selectedPos();
+    QVERIFY(pos.has_value());
+
+    // Shift forces a pencil mark while in Normal mode. QTest sends Key_4 + Shift
+    // (no native cooking), exercising the resolveDigit fallback path.
+    ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
+    QTest::keyClick(window_->board_widget_, Qt::Key_4, Qt::ShiftModifier);
+    QApplication::processEvents();
+    QVERIFY(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(4));
+
+    // Re-press removes the mark.
+    QTest::keyClick(window_->board_widget_, Qt::Key_4, Qt::ShiftModifier);
+    QApplication::processEvents();
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(4));
+
+    // Filled-cell guard: place a value, then Shift+digit is a no-op.
+    QTest::keyClick(window_->board_widget_, Qt::Key_6);  // Normal mode places 6
+    QApplication::processEvents();
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 6);
+    QTest::keyClick(window_->board_widget_, Qt::Key_2, Qt::ShiftModifier);
+    QApplication::processEvents();
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(2));
+
+    QTest::keyClick(window_->board_widget_, Qt::Key_Delete);  // cleanup
+    QApplication::processEvents();
+}
+
+void TestKeyboardHandling::altDigitAppliesColorWithToggleOff() {
+    selectEmptyCell();
+    auto pos = selectedPos();
+    QVERIFY(pos.has_value());
+
+    ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
+
+    QTest::keyClick(window_->board_widget_, Qt::Key_3, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(3));
+
+    // Different digit replaces the color.
+    QTest::keyClick(window_->board_widget_, Qt::Key_5, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(5));
+
+    // Same digit again removes it.
+    QTest::keyClick(window_->board_widget_, Qt::Key_5, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+}
+
+void TestKeyboardHandling::colorModePlainDigitAppliesColor() {
+    selectEmptyCell();
+    auto pos = selectedPos();
+    QVERIFY(pos.has_value());
+
+    // The previously-untested Color-mode application path: a plain digit in Color mode.
+    ctx_->game_vm->setInputMode(viewmodel::InputMode::Color);
+    QTest::keyClick(window_->board_widget_, Qt::Key_2);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(2));
+
+    // Plain Color mode is set-only (AC-1): re-pressing the same digit must NOT toggle the color off
+    // (toggle-off is exclusive to the Alt override). This guards the trickiest behavioural split.
+    QTest::keyClick(window_->board_widget_, Qt::Key_2);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(2));
+
+    ctx_->game_vm->colorCell(*pos, 0);  // cleanup
+    ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
+}
+
+void TestKeyboardHandling::altDigitSevenToNineIsNoOp() {
+    selectEmptyCell();
+    auto pos = selectedPos();
+    QVERIFY(pos.has_value());
+
+    QTest::keyClick(window_->board_widget_, Qt::Key_7, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+    QTest::keyClick(window_->board_widget_, Qt::Key_9, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+}
+
+void TestKeyboardHandling::eraseFamilyModifierCombos() {
+    selectEmptyCell();
+    auto pos = selectedPos();
+    QVERIFY(pos.has_value());
+    ctx_->game_vm->setInputMode(viewmodel::InputMode::Normal);
+
+    // Ctrl+0 clears the value in any mode.
+    QTest::keyClick(window_->board_widget_, Qt::Key_5);  // place a value
+    QApplication::processEvents();
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 5);
+    QTest::keyClick(window_->board_widget_, Qt::Key_0, Qt::ControlModifier);
+    QApplication::processEvents();
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).value, 0);
+
+    // Alt+0 clears the color.
+    QTest::keyClick(window_->board_widget_, Qt::Key_4, Qt::AltModifier);  // set color 4
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(4));
+    QTest::keyClick(window_->board_widget_, Qt::Key_0, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(colorAt(*pos), static_cast<uint8_t>(0));
+
+    // Shift+Delete clears all pencil marks in the cell.
+    QTest::keyClick(window_->board_widget_, Qt::Key_1, Qt::ShiftModifier);  // pencil 1
+    QTest::keyClick(window_->board_widget_, Qt::Key_3, Qt::ShiftModifier);  // pencil 3
+    QApplication::processEvents();
+    QVERIFY(ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(1));
+    QTest::keyClick(window_->board_widget_, Qt::Key_Delete, Qt::ShiftModifier);
+    QApplication::processEvents();
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(1));
+    QVERIFY(!ctx_->game_vm->gameState.get().getCell(pos->row, pos->col).notes.contains(3));
+}
+
+void TestKeyboardHandling::overrideOnGivenCellIsNoOp() {
+    auto given = findGivenCell();
+    QVERIFY(given.has_value());
+    window_->board_widget_->setSelectedCell(given.value());
+    QApplication::processEvents();
+
+    const int given_value = ctx_->game_vm->gameState.get().getCell(given->row, given->col).value;
+    QTest::keyClick(window_->board_widget_, Qt::Key_8, Qt::ControlModifier);
+    QApplication::processEvents();
+
+    // The given is untouched by the value override.
+    QCOMPARE(ctx_->game_vm->gameState.get().getCell(given->row, given->col).value, given_value);
+}
+
+std::optional<core::Position> TestKeyboardHandling::findGivenCell() const {
+    const auto& state = ctx_->game_vm->gameState.get();
+    for (size_t r = 0; r < core::BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < core::BOARD_SIZE; ++c) {
+            if (state.getCell(r, c).is_given) {
+                return core::Position{.row = r, .col = c};
+            }
+        }
+    }
+    return std::nullopt;
 }
 
 void TestKeyboardHandling::selectEmptyCell() {

--- a/tests/ui/test_resolve_digit.cpp
+++ b/tests/ui/test_resolve_digit.cpp
@@ -1,0 +1,114 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+#include "view/key_utils.h"
+#include "view_model/game_view_model.h"
+
+#include <optional>
+
+#include <QTest>
+#include <qnamespace.h>
+
+using namespace sudoku;
+using sudoku::view::overrideLayerFor;
+using sudoku::view::resolveDigit;
+using sudoku::viewmodel::InputMode;
+
+// Direct, layout-robust unit tests for the pure digit/override helpers (AC-6, AC-8).
+// These pass inputs in by hand rather than synthesizing native key events, because
+// QTest::keyClick does not populate nativeVirtualKey() — the helper must be correct
+// on the Key_1..Key_9 + Shift fallback path as well as the native physical-key path.
+class TestResolveDigit : public QObject {
+    Q_OBJECT
+
+private slots:
+    // resolveDigit -------------------------------------------------------------
+    void plainDigitResolves();
+    void ctrlDigitKeepsDigit();
+    void altDigitKeepsDigit();
+    void shiftDigitFallbackResolves();
+    void shiftGlyphResolvesFromNativeKey();
+    void nonDigitReturnsNullopt();
+    void zeroIsNotResolvedAsDigit();
+
+    // overrideLayerFor ---------------------------------------------------------
+    void noModifierMeansNoOverride();
+    void ctrlOverridesToValue();
+    void shiftOverridesToPencil();
+    void altOverridesToColor();
+    void keypadAloneIsNoOverride();
+};
+
+void TestResolveDigit::plainDigitResolves() {
+    QCOMPARE(resolveDigit(Qt::Key_5, Qt::NoModifier, 0), std::optional<int>(5));
+    QCOMPARE(resolveDigit(Qt::Key_1, Qt::NoModifier, 0), std::optional<int>(1));
+    QCOMPARE(resolveDigit(Qt::Key_9, Qt::NoModifier, 0), std::optional<int>(9));
+}
+
+void TestResolveDigit::ctrlDigitKeepsDigit() {
+    // Ctrl does not remap the key — Key_1..Key_9 stays intact.
+    QCOMPARE(resolveDigit(Qt::Key_3, Qt::ControlModifier, 0), std::optional<int>(3));
+}
+
+void TestResolveDigit::altDigitKeepsDigit() {
+    QCOMPARE(resolveDigit(Qt::Key_6, Qt::AltModifier, 0), std::optional<int>(6));
+}
+
+void TestResolveDigit::shiftDigitFallbackResolves() {
+    // The QTest path: synthesized Shift+digit keeps Key_1..Key_9 (no layout cooking),
+    // so the helper must accept it even without a native virtual key.
+    QCOMPARE(resolveDigit(Qt::Key_7, Qt::ShiftModifier, 0), std::optional<int>(7));
+}
+
+void TestResolveDigit::shiftGlyphResolvesFromNativeKey() {
+    // A real US keyboard cooks Shift+1 into Key_Exclam; recover the digit from the
+    // physical (native) key, which is not layout-dependent.
+#if defined(Q_OS_MACOS)
+    const quint32 native_one = 0x12;  // kVK_ANSI_1
+#else
+    const quint32 native_one = 0x31;  // Win VK '1' / X11 keysym XK_1 (both == ASCII '1')
+#endif
+    QCOMPARE(resolveDigit(Qt::Key_Exclam, Qt::ShiftModifier, native_one), std::optional<int>(1));
+}
+
+void TestResolveDigit::nonDigitReturnsNullopt() {
+    QCOMPARE(resolveDigit(Qt::Key_A, Qt::NoModifier, 0), std::nullopt);
+    QCOMPARE(resolveDigit(Qt::Key_Delete, Qt::NoModifier, 0), std::nullopt);
+    // A shifted glyph without a recognizable native key cannot be resolved.
+    QCOMPARE(resolveDigit(Qt::Key_Exclam, Qt::ShiftModifier, 0), std::nullopt);
+}
+
+void TestResolveDigit::zeroIsNotResolvedAsDigit() {
+    // 0 is the erase key, handled separately — resolveDigit only yields 1..9.
+    QCOMPARE(resolveDigit(Qt::Key_0, Qt::NoModifier, 0), std::nullopt);
+    QCOMPARE(resolveDigit(Qt::Key_0, Qt::ControlModifier, 0), std::nullopt);
+}
+
+void TestResolveDigit::noModifierMeansNoOverride() {
+    QCOMPARE(overrideLayerFor(Qt::NoModifier), std::optional<InputMode>(std::nullopt));
+}
+
+void TestResolveDigit::ctrlOverridesToValue() {
+    QCOMPARE(overrideLayerFor(Qt::ControlModifier), std::optional<InputMode>(InputMode::Normal));
+}
+
+void TestResolveDigit::shiftOverridesToPencil() {
+    QCOMPARE(overrideLayerFor(Qt::ShiftModifier), std::optional<InputMode>(InputMode::Notes));
+}
+
+void TestResolveDigit::altOverridesToColor() {
+    QCOMPARE(overrideLayerFor(Qt::AltModifier), std::optional<InputMode>(InputMode::Color));
+}
+
+void TestResolveDigit::keypadAloneIsNoOverride() {
+    // Numpad digits carry KeypadModifier but must still act on the active mode.
+    QCOMPARE(overrideLayerFor(Qt::KeypadModifier), std::optional<InputMode>(std::nullopt));
+}
+
+QTEST_MAIN(TestResolveDigit)
+#include "test_resolve_digit.moc"

--- a/tests/ui/test_resolve_digit.cpp
+++ b/tests/ui/test_resolve_digit.cpp
@@ -68,7 +68,7 @@ void TestResolveDigit::shiftDigitFallbackResolves() {
 void TestResolveDigit::shiftGlyphResolvesFromNativeKey() {
     // A real US keyboard cooks Shift+1 into Key_Exclam; recover the digit from the
     // physical (native) key, which is not layout-dependent.
-#if defined(Q_OS_MACOS)
+#ifdef Q_OS_MACOS
     const quint32 native_one = 0x12;  // kVK_ANSI_1
 #else
     const quint32 native_one = 0x31;  // Win VK '1' / X11 keysym XK_1 (both == ASCII '1')

--- a/tests/ui/test_training_widget.cpp
+++ b/tests/ui/test_training_widget.cpp
@@ -46,6 +46,21 @@ private:
     [[nodiscard]] QStackedWidget* pages() const {
         return trainingWidget()->pages_;
     }
+
+    // First editable (non-given, non-found) cell on the current training board. Returns a concrete
+    // Position (failing the test if none exists) so call sites avoid optional dereferences.
+    [[nodiscard]] core::Position findEditableTrainingCell() const {
+        const auto& board = trainingWidget()->training_vm_->trainingBoard.get();
+        for (size_t r = 0; r < core::BOARD_SIZE; ++r) {
+            for (size_t c = 0; c < core::BOARD_SIZE; ++c) {
+                if (!board[r][c].is_given && !board[r][c].is_found) {
+                    return core::Position{.row = r, .col = c};
+                }
+            }
+        }
+        QTest::qFail("No editable training cell found", __FILE__, __LINE__);
+        return core::Position{.row = 0, .col = 0};
+    }
 };
 
 void TestTrainingWidget::initTestCase() {
@@ -95,20 +110,10 @@ void TestTrainingWidget::testSharedBoardInputStillFunctions() {
     auto* vm = trainingWidget()->training_vm_.get();
     QVERIFY(vm != nullptr);
 
-    // Find an editable (non-given, non-found) cell to receive input, and select it on both the
-    // ViewModel (drives applyNumber/applyColor) and the widget.
-    std::optional<core::Position> editable;
-    const auto& initial = vm->trainingBoard.get();
-    for (size_t r = 0; r < core::BOARD_SIZE && !editable; ++r) {
-        for (size_t c = 0; c < core::BOARD_SIZE && !editable; ++c) {
-            if (!initial[r][c].is_given && !initial[r][c].is_found) {
-                editable = core::Position{.row = r, .col = c};
-            }
-        }
-    }
-    QVERIFY(editable.has_value());
-    vm->selectCell(editable->row, editable->col);
-    board->setSelectedCell(*editable);
+    // Select an editable cell on both the ViewModel (drives applyNumber/applyColor) and the widget.
+    const auto cell = findEditableTrainingCell();
+    vm->selectCell(cell.row, cell.col);
+    board->setSelectedCell(cell);
 
     QSignalSpy spy(board, &view::SudokuBoardWidget::digitKeyPressed);
 
@@ -122,12 +127,12 @@ void TestTrainingWidget::testSharedBoardInputStillFunctions() {
     QTest::keyClick(board, Qt::Key_1, Qt::AltModifier);
     QApplication::processEvents();
     QCOMPARE(spy.count(), 2);
-    QCOMPARE(vm->trainingBoard.get()[editable->row][editable->col].player_color, core::kMinPlayerColor);
+    QCOMPARE(vm->trainingBoard.get()[cell.row][cell.col].player_color, core::kMinPlayerColor);
 
     // Alt+5 is outside Training's two-color palette — it must be a no-op, leaving Color A intact.
     QTest::keyClick(board, Qt::Key_5, Qt::AltModifier);
     QApplication::processEvents();
-    QCOMPARE(vm->trainingBoard.get()[editable->row][editable->col].player_color, core::kMinPlayerColor);
+    QCOMPARE(vm->trainingBoard.get()[cell.row][cell.col].player_color, core::kMinPlayerColor);
 }
 
 void TestTrainingWidget::testSubmitAnswerShowsFeedback() {

--- a/tests/ui/test_training_widget.cpp
+++ b/tests/ui/test_training_widget.cpp
@@ -8,7 +8,10 @@
 
 #include "test_fixture.h"
 #include "view/main_window.h"
+#include "view/sudoku_board_widget.h"
 #include "view/training_widget.h"
+
+#include <optional>
 
 #include <QLabel>
 #include <QPushButton>
@@ -26,6 +29,7 @@ private slots:
     void testInitialPage();
     void testSelectTechniqueShowsTheory();
     void testStartExercisesShowsExercise();
+    void testSharedBoardInputStillFunctions();
     void testSubmitAnswerShowsFeedback();
     void testFeedbackButtonsExist();
     void testReturnToSelection();
@@ -77,6 +81,53 @@ void TestTrainingWidget::testStartExercisesShowsExercise() {
 
     QCOMPARE(pages()->currentIndex(), 2);
     QVERIFY(trainingWidget()->training_board_ != nullptr);
+}
+
+void TestTrainingWidget::testSharedBoardInputStillFunctions() {
+    // Shared-widget guard (AC-12): SudokuBoardWidget is reused by Training. After 0a.2 unified
+    // its key handling onto the single digitKeyPressed(digit, modifiers) signal, Training's board
+    // must still receive keyboard input AND apply it. Verify both the unified intent signal fires
+    // and the ViewModel actually mutates the board: an Alt+digit colors the cell (migrated from the
+    // retired A/B keys), and an out-of-palette Alt digit is rejected (no unrenderable player_color).
+    QCOMPARE(pages()->currentIndex(), 2);
+    auto* board = trainingWidget()->training_board_;
+    QVERIFY(board != nullptr);
+    auto* vm = trainingWidget()->training_vm_.get();
+    QVERIFY(vm != nullptr);
+
+    // Find an editable (non-given, non-found) cell to receive input, and select it on both the
+    // ViewModel (drives applyNumber/applyColor) and the widget.
+    std::optional<core::Position> editable;
+    const auto& initial = vm->trainingBoard.get();
+    for (size_t r = 0; r < core::BOARD_SIZE && !editable; ++r) {
+        for (size_t c = 0; c < core::BOARD_SIZE && !editable; ++c) {
+            if (!initial[r][c].is_given && !initial[r][c].is_found) {
+                editable = core::Position{.row = r, .col = c};
+            }
+        }
+    }
+    QVERIFY(editable.has_value());
+    vm->selectCell(editable->row, editable->col);
+    board->setSelectedCell(*editable);
+
+    QSignalSpy spy(board, &view::SudokuBoardWidget::digitKeyPressed);
+
+    // Plain digit still reaches the widget's unified intent signal.
+    QTest::keyClick(board, Qt::Key_5);
+    QApplication::processEvents();
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).toInt(), 5);
+
+    // Alt+1 colors the cell (Color A) — assert the applied effect, not just the signal.
+    QTest::keyClick(board, Qt::Key_1, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(spy.count(), 2);
+    QCOMPARE(vm->trainingBoard.get()[editable->row][editable->col].player_color, core::kMinPlayerColor);
+
+    // Alt+5 is outside Training's two-color palette — it must be a no-op, leaving Color A intact.
+    QTest::keyClick(board, Qt::Key_5, Qt::AltModifier);
+    QApplication::processEvents();
+    QCOMPARE(vm->trainingBoard.get()[editable->row][editable->col].player_color, core::kMinPlayerColor);
 }
 
 void TestTrainingWidget::testSubmitAnswerShowsFeedback() {

--- a/tests/unit/test_game_view_model_input_overrides.cpp
+++ b/tests/unit/test_game_view_model_input_overrides.cpp
@@ -50,7 +50,7 @@ TEST_CASE("GameViewModel - Modifier override routing", "[game_view_model][input_
 
     auto empty_opt = test::findEmptyCell(vm.gameState.get());
     REQUIRE(empty_opt.has_value());
-    const auto pos = empty_opt.value();
+    const auto pos = empty_opt.value_or(Position{});
 
     SECTION("Ctrl override forces a final value while in Notes mode (AC-2)") {
         vm.setInputMode(InputMode::Notes);
@@ -121,7 +121,7 @@ TEST_CASE("GameViewModel - Modifier override routing", "[game_view_model][input_
     SECTION("Overrides are no-ops on a locked given cell (AC-9)") {
         auto given_opt = findGivenCell(vm.gameState.get());
         REQUIRE(given_opt.has_value());
-        const auto given_pos = given_opt.value();
+        const auto given_pos = given_opt.value_or(Position{});
         const int given_value = vm.gameState.get().getCell(given_pos).value;
 
         vm.handleNumberInput(given_pos, (given_value % 9) + 1, InputMode::Normal);
@@ -137,7 +137,7 @@ TEST_CASE("GameViewModel - clearCellNotes clears only pencil marks", "[game_view
 
     auto empty_opt = test::findEmptyCell(vm.gameState.get());
     REQUIRE(empty_opt.has_value());
-    const auto pos = empty_opt.value();
+    const auto pos = empty_opt.value_or(Position{});
 
     SECTION("clearCellNotes removes every pencil mark in the cell (Shift+Delete, AC-5)") {
         vm.enterNote(pos, 2);

--- a/tests/unit/test_game_view_model_input_overrides.cpp
+++ b/tests/unit/test_game_view_model_input_overrides.cpp
@@ -1,0 +1,183 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "../helpers/game_view_model_fixture.h"
+#include "../helpers/test_utils.h"
+
+#include <optional>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace sudoku;
+using namespace sudoku::viewmodel;
+using namespace sudoku::core;
+
+using OverrideFixture = sudoku::test::GameViewModelFixture;
+
+namespace {
+// Find a given (locked) cell on the freshly generated board.
+std::optional<Position> findGivenCell(const model::GameState& state) {
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            if (state.getCell(r, c).is_given) {
+                return Position{.row = r, .col = c};
+            }
+        }
+    }
+    return std::nullopt;
+}
+}  // namespace
+
+// handleNumberInput with an explicit layer override is the net-new ViewModel entry point for
+// story 0a.2: Ctrl→value, Shift→pencil, Alt→color, regardless of the active InputMode.
+TEST_CASE("GameViewModel - Modifier override routing", "[game_view_model][input_mode][overrides]") {
+    OverrideFixture fixture;
+    fixture.view_model->startNewGame(Difficulty::Easy);
+    auto& vm = *fixture.view_model;
+
+    auto empty_opt = test::findEmptyCell(vm.gameState.get());
+    REQUIRE(empty_opt.has_value());
+    const auto pos = empty_opt.value();
+
+    SECTION("Ctrl override forces a final value while in Notes mode (AC-2)") {
+        vm.setInputMode(InputMode::Notes);
+
+        vm.handleNumberInput(pos, 5, InputMode::Normal);
+
+        REQUIRE(vm.gameState.get().getCell(pos).value == 5);
+    }
+
+    SECTION("Ctrl override re-press on the same value clears it (toggle-off, AC-2)") {
+        vm.setInputMode(InputMode::Color);
+
+        vm.handleNumberInput(pos, 4, InputMode::Normal);
+        REQUIRE(vm.gameState.get().getCell(pos).value == 4);
+
+        vm.handleNumberInput(pos, 4, InputMode::Normal);
+        REQUIRE(vm.gameState.get().getCell(pos).value == 0);
+    }
+
+    SECTION("Shift override toggles a pencil mark while in Normal mode (AC-3)") {
+        vm.setInputMode(InputMode::Normal);
+
+        vm.handleNumberInput(pos, 3, InputMode::Notes);
+        REQUIRE(vm.gameState.get().getCell(pos).notes.contains(3));
+
+        vm.handleNumberInput(pos, 3, InputMode::Notes);
+        REQUIRE_FALSE(vm.gameState.get().getCell(pos).notes.contains(3));
+    }
+
+    SECTION("Shift override on a filled cell is a no-op (empty-cell guard, AC-3)") {
+        vm.handleNumberInput(pos, 5, InputMode::Normal);  // place a value first
+        REQUIRE(vm.gameState.get().getCell(pos).value == 5);
+
+        vm.handleNumberInput(pos, 2, InputMode::Notes);  // pencil override on a filled cell
+
+        REQUIRE_FALSE(vm.gameState.get().getCell(pos).notes.contains(2));
+    }
+
+    SECTION("Alt override applies, replaces, and toggles off a color (AC-4)") {
+        vm.setInputMode(InputMode::Normal);
+
+        vm.handleNumberInput(pos, 3, InputMode::Color);
+        REQUIRE(vm.gameState.get().getCellColor(pos.row, pos.col) == 3);
+
+        // A different digit replaces the color.
+        vm.handleNumberInput(pos, 4, InputMode::Color);
+        REQUIRE(vm.gameState.get().getCellColor(pos.row, pos.col) == 4);
+
+        // The same digit again removes it.
+        vm.handleNumberInput(pos, 4, InputMode::Color);
+        REQUIRE(vm.gameState.get().getCellColor(pos.row, pos.col) == 0);
+    }
+
+    SECTION("Alt override for digits 7-9 is a silent no-op (palette is 1-6, AC-4)") {
+        vm.handleNumberInput(pos, 7, InputMode::Color);
+        REQUIRE(vm.gameState.get().getCellColor(pos.row, pos.col) == 0);
+        vm.handleNumberInput(pos, 9, InputMode::Color);
+        REQUIRE(vm.gameState.get().getCellColor(pos.row, pos.col) == 0);
+    }
+
+    SECTION("No override defaults to the active mode (AC-1 regression-safe)") {
+        vm.setInputMode(InputMode::Notes);
+        vm.handleNumberInput(pos, 6, std::nullopt);
+        REQUIRE(vm.gameState.get().getCell(pos).notes.contains(6));
+        REQUIRE(vm.gameState.get().getCell(pos).value == 0);
+    }
+
+    SECTION("Overrides are no-ops on a locked given cell (AC-9)") {
+        auto given_opt = findGivenCell(vm.gameState.get());
+        REQUIRE(given_opt.has_value());
+        const auto given_pos = given_opt.value();
+        const int given_value = vm.gameState.get().getCell(given_pos).value;
+
+        vm.handleNumberInput(given_pos, (given_value % 9) + 1, InputMode::Normal);
+
+        REQUIRE(vm.gameState.get().getCell(given_pos).value == given_value);
+    }
+}
+
+TEST_CASE("GameViewModel - clearCellNotes clears only pencil marks", "[game_view_model][overrides]") {
+    OverrideFixture fixture;
+    fixture.view_model->startNewGame(Difficulty::Easy);
+    auto& vm = *fixture.view_model;
+
+    auto empty_opt = test::findEmptyCell(vm.gameState.get());
+    REQUIRE(empty_opt.has_value());
+    const auto pos = empty_opt.value();
+
+    SECTION("clearCellNotes removes every pencil mark in the cell (Shift+Delete, AC-5)") {
+        vm.enterNote(pos, 2);
+        vm.enterNote(pos, 5);
+        vm.enterNote(pos, 8);
+        REQUIRE(vm.gameState.get().getCell(pos).notes.contains(2));
+
+        vm.clearCellNotes(pos);
+
+        const auto notes = vm.gameState.get().getCell(pos).notes;
+        REQUIRE_FALSE(notes.contains(2));
+        REQUIRE_FALSE(notes.contains(5));
+        REQUIRE_FALSE(notes.contains(8));
+    }
+}
+
+// In EditGivens the modifier is meaningless, not the keystroke: an override is stripped and the key
+// acts plain (so Ctrl+8/Alt+8 set given 8, matching the already-plain Ctrl+Delete given-clear).
+// This is the UX ruling (2026-06-04) replacing the earlier "override is a hard no-op" behaviour.
+TEST_CASE("GameViewModel - EditGivens strips modifier overrides and acts plain",
+          "[game_view_model][edit_mode][overrides]") {
+    OverrideFixture fixture;
+    fixture.view_model->enterEditMode();
+    auto& vm = *fixture.view_model;
+    const Position pos{.row = 3, .col = 5};
+
+    SECTION("A value override (Ctrl) in EditGivens sets the given, ignoring the modifier") {
+        vm.handleNumberInput(pos, 7, InputMode::Normal);  // Ctrl+7
+
+        REQUIRE(vm.gameState.get().getValue(pos) == 7);
+        REQUIRE(vm.gameState.get().isGiven(pos));
+    }
+
+    SECTION("A color override (Alt) in EditGivens also sets the given, then toggles it off") {
+        vm.handleNumberInput(pos, 7, InputMode::Color);  // Alt+7 → set given 7
+        REQUIRE(vm.gameState.get().getValue(pos) == 7);
+        REQUIRE(vm.gameState.get().isGiven(pos));
+
+        vm.handleNumberInput(pos, 7, InputMode::Color);  // same digit again clears the given
+        REQUIRE(vm.gameState.get().getValue(pos) == 0);
+        REQUIRE_FALSE(vm.gameState.get().isGiven(pos));
+    }
+}

--- a/tests/unit/test_training_view_model.cpp
+++ b/tests/unit/test_training_view_model.cpp
@@ -915,6 +915,37 @@ TEST_CASE("TrainingViewModel - undo history capped at max", "[training_view_mode
     CHECK(undo_count <= 50);
 }
 
+// --- applyColor range guard ---
+
+// Training has exactly two palette colors (A=1, B=2). The shared board widget resolves keyboard
+// digits 1..9, so applyColor must reject out-of-range digits — otherwise an Alt+digit chord could
+// write an unrenderable player_color (3..9) that is invisible but still recorded in undo history.
+TEST_CASE("TrainingViewModel - applyColor only accepts the two palette colors", "[training_view_model]") {
+    VMFixture f;
+    f.vm.selectTechnique(SolvingTechnique::NakedSingle);
+    f.vm.startExercises();
+    f.vm.selectCell(1, 0);  // (1,0) is editable (only (0,0)/(0,1) are given)
+
+    SECTION("Color A (1) and Color B (2) are applied") {
+        f.vm.applyColor(kMinPlayerColor);
+        CHECK(f.vm.trainingBoard.get()[1][0].player_color == kMinPlayerColor);
+
+        f.vm.applyColor(kMaxPlayerColor);
+        CHECK(f.vm.trainingBoard.get()[1][0].player_color == kMaxPlayerColor);
+    }
+
+    SECTION("Digits above the palette (3..9) are a no-op, leaving the existing color intact") {
+        f.vm.applyColor(kMaxPlayerColor);  // establish a valid color first
+        REQUIRE(f.vm.trainingBoard.get()[1][0].player_color == kMaxPlayerColor);
+
+        f.vm.applyColor(5);  // Alt+5 — outside the A/B palette
+        CHECK(f.vm.trainingBoard.get()[1][0].player_color == kMaxPlayerColor);
+
+        f.vm.applyColor(9);  // Alt+9 — outside the A/B palette
+        CHECK(f.vm.trainingBoard.get()[1][0].player_color == kMaxPlayerColor);
+    }
+}
+
 // --- Continue-on-correct flow ---
 
 namespace {


### PR DESCRIPTION
## Story 0a.2 — Keyboard bindings for value / pencil / color entry

Implements the modifier-override family, erase family, legacy-key cleanup, and the missing Color-mode UI test, per Sally's UX interaction spec (the source of truth). Builds on 0a.1's already-shipped mode-cycle verb.

### The one rule
A digit acts on the layer you name. **No modifier = the active mode's layer**; **Ctrl/Cmd = value**, **Shift = pencil**, **Alt/Option = color**. Same digit again undoes it.

### What's in this PR
- **Modifier overrides** (any mode): `Ctrl+digit`→value, `Shift+digit`→pencil, `Alt+digit`→color (1–6), each with toggle-off. `Alt+7–9` is a silent no-op (no wrap).
- **Erase family:** `Ctrl+0`/`Ctrl+Delete`→clear value, `Alt+0`/`Alt+Delete`→clear color, `Shift+Delete`→clear all pencil marks. Plain `Delete`/`0` unchanged.
- **`resolveDigit()`** — a pure, layout- and shift-glyph-aware helper that is the single digit resolution point. Recovers real `Shift+digit` from the physical (native) key, and accepts the `Key_1..9 + Shift` fallback that `QTest::keyClick` sends, so it's directly unit-testable.
- **Single raw-intent signal:** `SudokuBoardWidget` now emits one `digitKeyPressed(int digit, Qt::KeyboardModifiers)` (replacing `numberKeyPressed`/`colorKeyPressed`). Consumers apply meaning — `MainWindow` via `overrideLayerFor()`, the ViewModel owns routing + toggle-off. Value/pencil reuse `enterNumber`/`enterNote` (undoable); color reuses `colorCell` (ephemeral). No parallel undo logic (AC-13).
- **Legacy cleanup:** retired the `A`/`B` color keys and the `N` jump-to-Notes key (gameplay stays language-neutral; `Space`-cycle + `Alt+digit` cover them).
- **Shared-widget lockstep (AC-12):** Training migrates to the unified signal (`Alt+digit`→color, else→number); `TrainingViewModel::applyColor` is guarded to its 1–2 palette so the wider digit range can't write an unrenderable color.

### Design notes
- **`A`/`B` were already game no-ops** — `MainWindow` never consumed `colorKeyPressed`; only Training did. Retiring them removes the game keys and the Alt+digit path deliberately migrates Training's keyboard coloring.
- **AC-1 honored literally:** plain Color mode keeps its set-only behavior; only the Alt override adds toggle-off.
- `resolveDigit` lives in the view layer and is tested in the UI target because `unit_tests` excludes `src/view/`.

### Tests
- `tests/ui/test_resolve_digit.cpp` — direct unit tests for `resolveDigit`/`overrideLayerFor` (incl. the native Shift path, per-platform).
- `tests/unit/test_game_view_model_input_overrides.cpp` — override routing + `clearCellNotes`.
- `tests/ui/test_keyboard_handling.cpp` — every override/erase combo incl. the previously untested Color-mode application path, and given-cell no-op.
- `tests/ui/test_training_widget.cpp` — shared-widget input guard.

**Full suite green:** unit 1072 pass / 3 pre-existing skips, integration 14 cases, UI 14/14 (100%).

### Out of scope
Mode-button label, Keyboard Shortcuts dialog, status-line micro-hint, and the **CHANGELOG `[Unreleased]` entry** are deliberately deferred to **story 0a.3** (surfacing & docs) per the story scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)