### PR TITLE
test(solver): golden pin of all 54 technique ratings (0b.1)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,8 @@
             "toolchainFile": "${sourceDir}/build/Release/generators/conan_toolchain.cmake",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "SUDOKU_ENABLE_UI_TESTS": "ON"
             }
         },
         {
@@ -25,7 +26,8 @@
             "toolchainFile": "${sourceDir}/build/Debug/generators/conan_toolchain.cmake",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "SUDOKU_ENABLE_UI_TESTS": "ON"
             }
         },
         {
@@ -36,7 +38,8 @@
             "toolchainFile": "${sourceDir}/build/RelWithDebInfo/generators/conan_toolchain.cmake",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "SUDOKU_ENABLE_UI_TESTS": "ON"
             }
         }
     ],

--- a/tests/unit/test_technique_ratings.cpp
+++ b/tests/unit/test_technique_ratings.cpp
@@ -1,0 +1,142 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Golden characterization pin for getTechniqueRating() — Story 0b.1.
+//
+// Pins the *current* Sudoku Explainer (SE) rating of every one of the 54 logical
+// strategy techniques (NakedSingle(0) .. GroupedNiceLoop(53)). The persisted
+// difficulty/rating of saved puzzles is derived from these values (UK2 — save-pinned
+// values), so any change to getTechniqueRating() must be an explicit, reviewable
+// line-item diff. This pin is the guard that 0b.3's deliberate corrections will update.
+//
+// The expected table below is an EXPLICIT literal copied from the switch at
+// src/core/solving_technique.h — it is NOT derived by calling getTechniqueRating(),
+// which would make the pin vacuously self-consistent. Ground truth is the switch;
+// trust the switch over this copy if they ever disagree.
+//
+// This file is the *complete* save-compat pin and coexists with the partial
+// spot-checks in test_solving_technique.cpp (distinct [solver][ratings] tag/intent).
+
+#include "../../src/core/solving_technique.h"
+#include "../../src/core/training_learning_path.h"
+
+#include <array>
+#include <utility>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace sudoku::core;
+
+namespace {
+
+// Number of logical strategy techniques pinned here: NakedSingle(0) .. GroupedNiceLoop(53).
+// Backtracking (255) and the getTechniqueRating() 0.0 fallback are non-strategies and are
+// deliberately excluded — matching the cardinality convention used across the solver suite.
+constexpr int kPinnedStrategyCount = 54;
+
+// Explicit expected ratings in enum order (0..53), copied verbatim from the switch at
+// src/core/solving_technique.h:228-318. Watch the fall-through groups in the switch — several
+// distinct techniques share one return value (e.g. FinnedXWing/SashimiXWing/HiddenPair all 3.4).
+constexpr std::array<std::pair<SolvingTechnique, double>, kPinnedStrategyCount> kExpectedRatings = {{
+    {SolvingTechnique::NakedSingle, 2.3},
+    {SolvingTechnique::HiddenSingle, 1.5},
+    {SolvingTechnique::NakedPair, 3.0},
+    {SolvingTechnique::NakedTriple, 3.6},
+    {SolvingTechnique::HiddenPair, 3.4},
+    {SolvingTechnique::HiddenTriple, 4.0},
+    {SolvingTechnique::PointingPair, 2.6},
+    {SolvingTechnique::BoxLineReduction, 2.8},
+    {SolvingTechnique::NakedQuad, 5.0},
+    {SolvingTechnique::HiddenQuad, 5.4},
+    {SolvingTechnique::XWing, 3.2},
+    {SolvingTechnique::XYWing, 4.2},
+    {SolvingTechnique::Swordfish, 3.8},
+    {SolvingTechnique::Skyscraper, 4.0},
+    {SolvingTechnique::TwoStringKite, 4.1},
+    {SolvingTechnique::XYZWing, 4.4},
+    {SolvingTechnique::UniqueRectangle, 4.5},
+    {SolvingTechnique::WWing, 4.4},
+    {SolvingTechnique::SimpleColoring, 4.0},
+    {SolvingTechnique::FinnedXWing, 3.4},
+    {SolvingTechnique::RemotePairs, 4.5},
+    {SolvingTechnique::BUG, 5.6},
+    {SolvingTechnique::Jellyfish, 5.2},
+    {SolvingTechnique::FinnedSwordfish, 4.0},
+    {SolvingTechnique::EmptyRectangle, 4.5},
+    {SolvingTechnique::WXYZWing, 4.6},
+    {SolvingTechnique::FinnedJellyfish, 5.4},
+    {SolvingTechnique::XYChain, 6.6},
+    {SolvingTechnique::MultiColoring, 4.2},
+    {SolvingTechnique::ALSxZ, 7.5},
+    {SolvingTechnique::SueDeCoq, 7.5},
+    {SolvingTechnique::ForcingChain, 7.5},
+    {SolvingTechnique::NiceLoop, 7.5},
+    {SolvingTechnique::XCycles, 6.6},
+    {SolvingTechnique::ThreeDMedusa, 4.4},
+    {SolvingTechnique::HiddenUniqueRectangle, 4.8},
+    {SolvingTechnique::AvoidableRectangle, 4.5},
+    {SolvingTechnique::ALSXYWing, 7.8},
+    {SolvingTechnique::DeathBlossom, 8.2},
+    {SolvingTechnique::VWXYZWing, 4.8},
+    {SolvingTechnique::FrankenFish, 4.2},
+    {SolvingTechnique::GroupedXCycles, 6.8},
+    {SolvingTechnique::SashimiXWing, 3.4},
+    {SolvingTechnique::SashimiSwordfish, 4.2},
+    {SolvingTechnique::SashimiJellyfish, 5.6},
+    {SolvingTechnique::UnitForcingChain, 7.8},
+    {SolvingTechnique::RegionForcingChain, 8.0},
+    {SolvingTechnique::MutantFish, 5.4},
+    {SolvingTechnique::KrakenFish, 8.5},
+    {SolvingTechnique::ALSChain, 8.5},
+    {SolvingTechnique::JuniorExocet, 9.4},
+    {SolvingTechnique::UniqueLoop, 4.5},
+    {SolvingTechnique::ContinuousNiceLoop, 7.0},
+    {SolvingTechnique::GroupedNiceLoop, 8.0},
+}};
+
+}  // namespace
+
+TEST_CASE("getTechniqueRating() golden pin — all 54 strategy ratings", "[solver][ratings]") {
+    SECTION("Each strategy technique returns its pinned current rating") {
+        for (const auto& [technique, expected] : kExpectedRatings) {
+            // Name the offending technique if a future drift makes this go RED.
+            CAPTURE(getTechniqueName(technique), static_cast<int>(technique), expected);
+            // Ratings are exact double literals (multiples of 0.1) used identically on both
+            // sides — direct == is intentional. No epsilon: it would weaken the pin against a
+            // deliberate 0.1-step correction (the very change 0b.3 will make).
+            REQUIRE(getTechniqueRating(technique) == expected);
+        }
+    }
+
+    SECTION("Cardinality guard — exactly 54 strategies are pinned") {
+        // Adding a new SolvingTechnique strategy without pinning its rating must fail here.
+        REQUIRE(kExpectedRatings.size() == kPinnedStrategyCount);
+
+        // Cross-witnesses that 54 is the live strategy count (independent of this table).
+        REQUIRE(static_cast<int>(kLastLogicalTechnique) == kPinnedStrategyCount - 1);
+        REQUIRE(kAllTechniques.size() == kPinnedStrategyCount);
+    }
+
+    SECTION("constexpr-evaluability is preserved (spot check)") {
+        // getTechniqueRating() is constexpr; pin that property so it cannot silently regress.
+        STATIC_REQUIRE(getTechniqueRating(SolvingTechnique::NakedSingle) == 2.3);
+    }
+
+    SECTION("Backtracking is documented but excluded from the 54-row pin") {
+        // Backtracking is the brute-force fallback, not a logical strategy — outside the count.
+        REQUIRE(getTechniqueRating(SolvingTechnique::Backtracking) == 12.0);
+    }
+}

--- a/tests/unit/test_technique_ratings.cpp
+++ b/tests/unit/test_technique_ratings.cpp
@@ -109,6 +109,9 @@ constexpr std::array<std::pair<SolvingTechnique, double>, kPinnedStrategyCount> 
 
 }  // namespace
 
+// Catch2 TEST_CASE: the SECTIONs + the 54-row pin loop expand to nested conditionals, so the
+// generated function trips the cognitive-complexity threshold; complexity is inherent to the pin.
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("getTechniqueRating() golden pin — all 54 strategy ratings", "[solver][ratings]") {
     SECTION("Each strategy technique returns its pinned current rating") {
         for (const auto& [technique, expected] : kExpectedRatings) {


### PR DESCRIPTION
## Story 0b.1 — Golden pin of current ratings

Epic 0b (Solver Difficulty (SE) Rating Audit & Correction), step 1 of **pin → audit → correct**. Pins *today's* `getTechniqueRating()` values so 0b.2 (audit) and 0b.3 (correct) produce explicit, reviewable diffs and accidental drift fails loudly.

### What this does
- Adds `tests/unit/test_technique_ratings.cpp` (`[solver][ratings]`) — a **complete** characterization pin of `getTechniqueRating()` for all **54** logical strategy techniques (`NakedSingle`(0) … `GroupedNiceLoop`(53)).
- Expected ratings are an **explicit literal table** in enum order copied verbatim from the switch in `src/core/solving_technique.h` — *not* derived by calling the function under test, so the pin is not vacuously self-consistent.
- **Cardinality guard:** asserts exactly 54 pinned entries, cross-checked against two independent live witnesses (`kLastLogicalTechnique == 53`, `kAllTechniques.size() == 54`). Adding a strategy without pinning its rating fails the test.
- `Backtracking` (12.0) asserted separately as documentation, outside the 54-count; `0.0` fallback not pinned. Direct `==` on exact doubles (no epsilon), so a deliberate 0.1-step correction in 0b.3 trips the pin. One `STATIC_REQUIRE` pins `constexpr`-evaluability.

### Build-config fix (folded in)
`SUDOKU_ENABLE_UI_TESTS` (default `OFF`) was only `ON` via a manually-cached flag in `build/Debug`; `build/Release` had it `OFF`, so the documented gate `ctest --test-dir build/Release -R "^test_"` found **zero** UI tests. Set `SUDOKU_ENABLE_UI_TESTS=ON` in all three `CMakePresets.json` configure presets so the documented Release UI-test gate builds & runs on a clean checkout.

### Verification
- **U6 RED-bite:** flipped `NakedSingle` 2.3 → 9.9 → RED (`2.3… == 9.9…`); reverted → GREEN.
- **Full U3 gate (Release):** unit 15791 assertions ✓ · integration 270 ✓ · UI 15/15 ✓.

### CHANGELOG
Deliberately **skipped** — test-only addition plus a repo-owned dev-preset default; no user/packager-visible behavior, no `make install` impact. The user-facing entry lands in 0b.3 when a real rating value changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)