### PR TITLE
fix(ci): extract rateAndValidatePuzzle to fix nightly clang-tidy function-size gate

### DIFF
--- a/src/core/puzzle_generator.cpp
+++ b/src/core/puzzle_generator.cpp
@@ -137,33 +137,9 @@ std::expected<Puzzle, GenerationError> PuzzleGenerator::generatePuzzle(const Gen
         result.seed = actual_seed;
         result.clue_count = countClues(result.board);
 
-        // Rate puzzle if rater is available
-        if (rater_) {
-            auto rating_result = rater_->ratePuzzle(result.board);
-            if (rating_result.has_value()) {
-                result.rating = rating_result->se_rating;
-                result.requires_backtracking = rating_result->requires_backtracking;
-                for (const auto& step : rating_result->solve_path) {
-                    if (step.technique != SolvingTechnique::Backtracking) {
-                        result.required_techniques.insert(step.technique);
-                    }
-                }
-                spdlog::info("Puzzle rated: SE {:.1f}", result.rating);
-
-                // Validate rating: reject puzzles outside the expected range for their difficulty
-                {
-                    auto [min_rating, max_rating] = getDifficultyRatingRange(settings.difficulty);
-                    if (result.rating < min_rating || result.rating >= max_rating) {
-                        spdlog::debug("Puzzle rating {} outside range [{}, {}), rejecting...", result.rating,
-                                      min_rating, max_rating);
-                        continue;  // Try again with different puzzle
-                    }
-                    spdlog::debug("Puzzle rating {} within range [{}, {})", result.rating, min_rating, max_rating);
-                }
-            } else {
-                spdlog::warn("Failed to rate puzzle: {}", static_cast<int>(rating_result.error()));
-                // Continue without rating if rating fails (don't reject puzzle)
-            }
+        // Rate puzzle and reject it if it falls outside the expected difficulty band
+        if (!rateAndValidatePuzzle(result, settings)) {
+            continue;  // Try again with a different puzzle
         }
 
         return result;
@@ -172,6 +148,36 @@ std::expected<Puzzle, GenerationError> PuzzleGenerator::generatePuzzle(const Gen
     // All attempts failed
     spdlog::error("Failed to generate puzzle after {} attempts", settings.max_attempts);
     return std::unexpected(GenerationError::NoUniqueSolution);
+}
+
+bool PuzzleGenerator::rateAndValidatePuzzle(Puzzle& result, const GenerationSettings& settings) const {
+    if (!rater_) {
+        return true;  // No rater configured: accept the puzzle as-is
+    }
+
+    auto rating_result = rater_->ratePuzzle(result.board);
+    if (!rating_result.has_value()) {
+        spdlog::warn("Failed to rate puzzle: {}", static_cast<int>(rating_result.error()));
+        return true;  // Continue without rating if rating fails (don't reject puzzle)
+    }
+
+    result.rating = rating_result->se_rating;
+    result.requires_backtracking = rating_result->requires_backtracking;
+    for (const auto& step : rating_result->solve_path) {
+        if (step.technique != SolvingTechnique::Backtracking) {
+            result.required_techniques.insert(step.technique);
+        }
+    }
+    spdlog::info("Puzzle rated: SE {:.1f}", result.rating);
+
+    // Validate rating: reject puzzles outside the expected range for their difficulty
+    auto [min_rating, max_rating] = getDifficultyRatingRange(settings.difficulty);
+    if (result.rating < min_rating || result.rating >= max_rating) {
+        spdlog::debug("Puzzle rating {} outside range [{}, {}), rejecting...", result.rating, min_rating, max_rating);
+        return false;
+    }
+    spdlog::debug("Puzzle rating {} within range [{}, {})", result.rating, min_rating, max_rating);
+    return true;
 }
 
 std::expected<Puzzle, GenerationError> PuzzleGenerator::generatePuzzle(Difficulty difficulty) const {

--- a/src/core/puzzle_generator.h
+++ b/src/core/puzzle_generator.h
@@ -141,6 +141,11 @@ private:
     /// Generates a complete valid Sudoku solution
     std::optional<BoardData> generateCompleteSolution(std::mt19937& rng) const;
 
+    /// Rates a candidate puzzle (when a rater is configured) and confirms it falls within the
+    /// expected SE range for its difficulty. Populates rating / required_techniques / backtracking
+    /// flags on @p result. Returns false when the puzzle must be rejected so the caller retries.
+    [[nodiscard]] bool rateAndValidatePuzzle(Puzzle& result, const GenerationSettings& settings) const;
+
     /// Removes clues from a complete solution to create a puzzle
     std::optional<BoardData> removeCluesToCreatePuzzle(const BoardData& solution, const GenerationSettings& settings,
                                                        std::mt19937& rng) const;


### PR DESCRIPTION
## Problem

The nightly run ([27665937469](https://github.com/darkstar79/sudoku/actions/runs/27665937469)) failed in the **clang-tidy** job only (the other four jobs passed). Root cause was a single diagnostic:

```
src/core/puzzle_generator.cpp:64:57: error: function 'generatePuzzle' exceeds recommended size/complexity thresholds [readability-function-size]
note: 111 lines including whitespace and comments (threshold 100)
```

Commit #81 (ITimeProvider determinism audit) added the `actual_seed` lambda block to `generatePuzzle`, pushing it from under 100 to 111 lines. The **per-PR CI clang-tidy only checks changed lines**, so it never re-evaluated whole-function size — only the nightly's full-file run catches this class of regression.

## Fix

Extract the rating + difficulty-range validation block (~28 lines) out of `generatePuzzle` into a new private helper `rateAndValidatePuzzle(Puzzle&, const GenerationSettings&)`. Pure behavior-preserving refactor: the helper returns `false` when the puzzle must be rejected, so the caller `continue`s exactly as the inline block did. `generatePuzzle` is now 88 lines.

## Verification

- ✅ clang-tidy (full root config, `--warnings-as-errors=*`) on the file: clean
- ✅ Release build compiles
- ✅ `[puzzle_generator]` tests: 55 cases / 1606 assertions pass
- ✅ Full fast unit suite: 1097 passed, 3 skipped, 17304 assertions
- ✅ clang-format clean

**CHANGELOG:** intentionally skipped — internal-only refactor, no user- or packager-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)