### PR TITLE
ci: gate patch coverage (diff-cover) and unit-only ASan/UBSan on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Full history so the patch-coverage step can resolve the merge-base
+          # with origin/main for `diff-cover`.
+          fetch-depth: 0
 
       - name: Install system dependencies
         uses: ./.github/actions/install-qt-deps
@@ -218,6 +222,97 @@ jobs:
             coverage.xml
             coverage_report.html
           retention-days: 30
+
+      - name: Enforce patch coverage on changed lines
+        if: github.event_name == 'pull_request'
+        # The absolute gcovr thresholds above let new code ride on the existing
+        # average (new code can be 0% covered and still pass). diff-cover instead
+        # requires the lines changed in THIS PR — those that appear in the
+        # src/-only coverage.xml — to be >=80% covered. It reuses the coverage.xml
+        # already produced above, so there is no extra build or test run.
+        # (View-layer / test files are excluded from coverage.xml by .gcovr.cfg
+        # and are therefore simply not measured here.)
+        run: |
+          pip3 install diff-cover
+          git fetch --no-tags origin main
+          echo "Checking patch coverage (changed src/ lines must be >=80% covered)..."
+          diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+          echo "✅ Patch coverage threshold met"
+
+  sanitizers-unit:
+    name: ASan + UBSan (unit)
+    runs-on: ubuntu-24.04
+    needs: format-check
+    # Unit-suite-only ASan+UBSan on every PR: catches the common UB classes
+    # (uninitialized reads, the AVX-512 alignment SIGSEGV class) at PR time
+    # rather than hours later via nightly. To bound per-PR runner minutes this
+    # builds ONLY the unit_tests target and runs ONLY the unit suite; the
+    # exhaustive sanitizer run (integration tests + full corpus) stays in
+    # nightly.yml's sanitizer-check.
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        uses: ./.github/actions/install-qt-deps
+
+      - name: Install Conan
+        run: |
+          pip3 install conan
+          conan profile detect --force
+
+      - name: Cache Conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-release-${{ hashFiles('conanfile.py') }}-${{ github.sha }}
+          restore-keys: |
+            conan-${{ runner.os }}-release-${{ hashFiles('conanfile.py') }}-
+            conan-${{ runner.os }}-release-
+
+      # Shares the rel-san ccache flavor with nightly's sanitizer-check (identical
+      # Release + ENABLE_SANITIZERS compile flags). This job compiles only the
+      # unit_tests target — a strict subset of nightly's objects — so everything it
+      # builds is cache-compatible. The ${github.sha} suffix keeps the two workflows
+      # from colliding on save; cache-cleanup.yml reclaims closed-PR entries.
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-rel-san-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-rel-san-
+
+      - name: Configure ccache
+        run: |
+          ccache --set-config=max_size=1Gi
+          ccache --zero-stats
+
+      - name: Install dependencies
+        run: conan install . --build=missing -s build_type=Release -s compiler.cppstd=gnu23
+
+      - name: Build unit tests with sanitizers
+        run: |
+          cmake --preset release -DENABLE_SANITIZERS=ON
+          cmake --build --preset release --target unit_tests
+
+      - name: Show ccache stats
+        run: ccache --show-stats
+
+      - name: Run unit tests under ASan + UBSan
+        env:
+          ASAN_OPTIONS: "detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:halt_on_error=1"
+          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+        run: |
+          if [ -f "build/Release/build/Release/bin/tests/unit_tests" ]; then
+            UNIT_TESTS="build/Release/build/Release/bin/tests/unit_tests"
+          else
+            UNIT_TESTS="build/Release/bin/tests/unit_tests"
+          fi
+          echo "Running: $UNIT_TESTS"
+          "$UNIT_TESTS" "~[slow]~[pathological]"
 
   clang-tidy-diff:
     name: clang-tidy (diff)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,11 @@ conan>=2.18.1
 # on system packages.
 cmake>=3.28
 ninja>=1.11
+
+# Patch-coverage gate. CI (.github/workflows/ci.yml) runs diff-cover on the
+# src/-only coverage.xml so changed lines must be >=80% covered; listed here so
+# the same check is reproducible locally:
+#   ./scripts/coverage.sh xml
+#   diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+# (gcovr is installed inline by CI and intentionally not pinned here.)
+diff-cover>=9.0


### PR DESCRIPTION
## Summary

- **Patch coverage (diff-cover).** The absolute gcovr thresholds let new code ride on the existing average (new code can be 0% covered and still pass). Adds a PR-only `diff-cover` step to `test-and-coverage` requiring the lines changed in the PR — those present in the `src/`-only `coverage.xml` — to be ≥80% covered. Reuses the `coverage.xml` already produced by `scripts/coverage.sh`, so **no extra build or test run**; checkout gains `fetch-depth: 0` to resolve the `origin/main` merge-base.
- **Unit-only ASan+UBSan (`sanitizers-unit`).** New per-PR job builds **only** the `unit_tests` target with `-DENABLE_SANITIZERS=ON` and runs **only** the unit suite under ASan+UBSan — catching the common UB classes (uninitialized reads, the AVX-512 alignment SIGSEGV class) at PR time instead of hours later. Shares nightly's `rel-san` ccache flavor (identical flags, subset of objects). The **exhaustive** sanitizer run (integration + full corpus) stays in `nightly.yml`, preserving the PR→nightly compute split.
- `requirements.txt`: pin `diff-cover` so the patch-coverage check is reproducible locally.

No CHANGELOG entry — CI / dev-tooling only, invisible to end users and packagers.

## Test plan

- [x] `ci.yml` validated as well-formed YAML; jobs resolve (`…, test-and-coverage, sanitizers-unit, clang-tidy-diff, …`).
- [x] `unit_tests` confirmed as a real CMake target (`tests/unit/CMakeLists.txt`); `ENABLE_SANITIZERS` confirmed as a real option (`CMakeLists.txt`).
- [x] `diff-cover` invocation mirrors the gcovr cobertura `coverage.xml` (src/-only filter) — view/test changes are not measured.
- [x] `sanitizers-unit` mirrors nightly `sanitizer-check` env/flags/filter exactly, scoped to the unit target+suite.
- [ ] First PR run confirms: diff-cover step executes and reports patch coverage; `sanitizers-unit` builds + runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)