### PR TITLE
build: cross-platform clang-format discovery in format.sh and pre-commit

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -14,16 +14,44 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Find clang-format
-CLANG_FORMAT=$(command -v clang-format || echo "")
+# Find clang-format across platforms: PATH (incl. versioned names like clang-format-19),
+# macOS Homebrew LLVM (keg-only, not on PATH), and Windows LLVM installs.
+# Override on any machine with: CLANG_FORMAT=/path/to/clang-format ./scripts/format.sh
+find_clang_format() {
+    if [ -n "${CLANG_FORMAT:-}" ] && command -v "$CLANG_FORMAT" >/dev/null 2>&1; then
+        command -v "$CLANG_FORMAT"; return 0
+    fi
+    local c
+    for c in clang-format clang-format-22 clang-format-21 clang-format-20 \
+             clang-format-19 clang-format-18 clang-format-17 clang-format-16 clang-format-15; do
+        if command -v "$c" >/dev/null 2>&1; then command -v "$c"; return 0; fi
+    done
+    local p
+    if command -v brew >/dev/null 2>&1; then
+        for p in "$(brew --prefix llvm 2>/dev/null)/bin/clang-format" \
+                 "$(brew --prefix clang-format 2>/dev/null)/bin/clang-format"; do
+            [ -x "$p" ] && { echo "$p"; return 0; }
+        done
+    fi
+    for p in /opt/homebrew/opt/llvm/bin/clang-format \
+             /usr/local/opt/llvm/bin/clang-format \
+             "/c/Program Files/LLVM/bin/clang-format.exe" \
+             "/c/Program Files (x86)/LLVM/bin/clang-format.exe"; do
+        [ -x "$p" ] && { echo "$p"; return 0; }
+    done
+    return 1
+}
+
+CLANG_FORMAT="$(find_clang_format || true)"
 if [ -z "$CLANG_FORMAT" ]; then
     echo -e "${RED}Error: clang-format not found${NC}"
-    echo "Install with: sudo dnf install clang-tools-extra"
+    echo "Install: Fedora 'sudo dnf install clang-tools-extra' | macOS 'brew install llvm' | Windows: LLVM installer"
+    echo "Or set CLANG_FORMAT=/path/to/clang-format"
     exit 1
 fi
 
 # Check clang-format version
-VERSION=$($CLANG_FORMAT --version | grep -oP '(?<=version )\d+' | head -1)
+VERSION=$("$CLANG_FORMAT" --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p' | head -1)
 if [ "$VERSION" -lt 15 ]; then
     echo -e "${YELLOW}Warning: clang-format version $VERSION detected${NC}"
     echo -e "${YELLOW}InsertBraces feature requires version 15+${NC}"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -65,16 +65,35 @@ else
 fi
 
 # Check 2: Code formatting (staged files only, ~instant)
-# Locate clang-format: PATH first, then common Homebrew locations (macOS)
-CLANG_FORMAT=$(command -v clang-format 2>/dev/null || true)
-if [ -z "$CLANG_FORMAT" ]; then
-    for candidate in /opt/homebrew/opt/llvm/bin/clang-format /usr/local/opt/llvm/bin/clang-format; do
-        if [ -x "$candidate" ]; then
-            CLANG_FORMAT="$candidate"
-            break
-        fi
+# Locate clang-format across platforms: PATH (incl. versioned names), macOS Homebrew LLVM
+# (keg-only, not on PATH), and Windows LLVM installs. Override with CLANG_FORMAT=/path.
+# Kept in sync with scripts/format.sh and .claude/hooks/format-changed.py.
+find_clang_format() {
+    if [ -n "${CLANG_FORMAT:-}" ] && command -v "$CLANG_FORMAT" >/dev/null 2>&1; then
+        command -v "$CLANG_FORMAT"; return 0
+    fi
+    local c
+    for c in clang-format clang-format-22 clang-format-21 clang-format-20 \
+             clang-format-19 clang-format-18 clang-format-17 clang-format-16 clang-format-15; do
+        if command -v "$c" >/dev/null 2>&1; then command -v "$c"; return 0; fi
     done
-fi
+    local p
+    if command -v brew >/dev/null 2>&1; then
+        for p in "$(brew --prefix llvm 2>/dev/null)/bin/clang-format" \
+                 "$(brew --prefix clang-format 2>/dev/null)/bin/clang-format"; do
+            [ -x "$p" ] && { echo "$p"; return 0; }
+        done
+    fi
+    for p in /opt/homebrew/opt/llvm/bin/clang-format \
+             /usr/local/opt/llvm/bin/clang-format \
+             "/c/Program Files/LLVM/bin/clang-format.exe" \
+             "/c/Program Files (x86)/LLVM/bin/clang-format.exe"; do
+        [ -x "$p" ] && { echo "$p"; return 0; }
+    done
+    return 1
+}
+
+CLANG_FORMAT="$(find_clang_format || true)"
 
 if [ -z "$CLANG_FORMAT" ] || [ ! -x "$CLANG_FORMAT" ]; then
     echo -e "${YELLOW}[pre-commit] clang-format not found — skipping formatting check.${NC}"


### PR DESCRIPTION
## Summary

- `scripts/format.sh` failed on macOS: it only checked `command -v clang-format` (Homebrew LLVM is keg-only / off PATH) and parsed the version with GNU-only `grep -oP`.
- Adds a shared `find_clang_format()` that searches PATH (incl. versioned names like `clang-format-19`), `brew --prefix llvm`, fixed macOS/Windows install paths, and a `CLANG_FORMAT` override; switches the version parse to portable `sed`.
- Mirrors the same discovery into `scripts/pre-commit` so the hook resolves clang-format identically across Fedora / macOS / Windows.

No CHANGELOG entry — dev-only tooling scripts, invisible to end users and packagers.

## Test plan

- [x] `bash -n` syntax-clean on both scripts.
- [x] `./scripts/format.sh check` runs on macOS (Homebrew LLVM, off PATH) — scans 378 files, exits clean. Previously errored at "clang-format not found".
- [x] Discovery resolves `/opt/homebrew/opt/llvm/bin/clang-format` on this Mac; `CLANG_FORMAT=…` override honored.
- [ ] CI `format-check` (Linux, `clang-format==22.1.5` on PATH) stays green — PATH branch unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)