### PR TITLE
ci(packaging): gate macOS DMG to on-demand, exclude it from tagged releases

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -186,13 +186,22 @@ jobs:
     name: macOS DMG (Universal Binary)
     runs-on: macos-15
     timeout-minutes: 45
+    # macOS is out of scope for 1.0.0: there is no Apple Developer account, so
+    # the DMG cannot be code-signed/notarized and would only ship as an unsigned
+    # (Gatekeeper-hostile) image. Build it on demand only, and keep it OUT of the
+    # `release` job's `needs` so it never gates a tagged release.
+    # NOTE: the universal build below still needs work before it can be relied on
+    # — conanfile.py's layout() hardcodes build/Release/generators, so the
+    # per-arch `--output-folder=build/{arm64,x86_64}` does not place the Conan
+    # toolchain where the configure step looks for it. Fix that first.
+    if: github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install Qt6
-        run: brew install qt
+      - name: Install Qt6 and Ninja
+        run: brew install qt ninja
 
       - name: Set QT6_DIR
         run: echo "QT6_DIR=$(brew --prefix qt)/lib/cmake/Qt6" >> "$GITHUB_ENV"
@@ -280,7 +289,9 @@ jobs:
     name: Upload Release Assets
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
-    needs: [flatpak, appimage, installer, dmg]
+    # macOS DMG intentionally excluded — it is gated to workflow_dispatch only
+    # (see the dmg job) and is not part of a tagged release.
+    needs: [flatpak, appimage, installer]
     permissions:
       contents: write
 
@@ -293,8 +304,11 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Pre-release tags carry a hyphen (e.g. v1.0.0-rc1); final tags
+          # (v1.0.0) do not. Mark RCs as pre-release and keep them off "latest".
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           files: |
             Sudoku-*.flatpak
             Sudoku-*.AppImage
             Sudoku-*-win64.exe
-            Sudoku-*-macOS.dmg


### PR DESCRIPTION
## Why

The `v1.0.0-rc1` tag push triggered Packaging ([run 27976824848](https://github.com/darkstar79/sudoku/actions/runs/27976824848)). Three platforms built fine (AppImage, Flatpak, Windows installer), but the **macOS DMG job failed** at CMake configure:

- Ninja is never installed in the `dmg` job (`brew install qt` only)
- the job passes `--output-folder=build/arm64` but `conanfile.py`'s `layout()` hardcodes `build/Release/generators`, so the Conan toolchain isn't where the configure step looks for it

Because the `release` job required **all four** platforms (`needs: […, dmg]`), the macOS failure **gated the entire release** — the three in-scope packages were never published.

## Decision

**macOS is out of scope for 1.0.0**: there's no Apple Developer account, so a DMG can only ship **unsigned / un-notarized** (Gatekeeper-hostile). Rather than fix the universal build now, this PR:

- **Gates the `dmg` job to `workflow_dispatch` only** — keeps the build capability on demand, never runs on a tag.
- **Drops `dmg` from the `release` job's `needs`** → tagged releases publish Flatpak + AppImage + Windows without being blocked by macOS.
- Adds the missing **`brew install … ninja`** to the dmg job.
- **Auto-classifies pre-releases**: hyphenated tags (e.g. `v1.0.0-rc1`) are marked `prerelease` and kept off "Latest"; final tags (`v1.0.0`) publish as a normal latest release.
- Comments the remaining Conan per-arch toolchain-path issue for whoever revisits the universal build.

## Changelog

CI/packaging-only change — no install-tree or downstream-packager impact (the OBS namespaces build from source, not from these GitHub release assets), and macOS was never published, so no user-facing regression. **No CHANGELOG entry.**

> Note: the `[Unreleased]` "macOS build support" line is left untouched and may want rewording separately, depending on whether macOS *build* support is still claimed for 1.0.0.

## Next

After merge: re-tag `v1.0.0-rc1` on the new `main` HEAD and push → Packaging publishes the 3-platform RC pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)