### PR TITLE
feat(engine): add reconstruct() board+candidate primitive (A.0 keystone)

### DIFF
--- a/src/core/reconstruction.cpp
+++ b/src/core/reconstruction.cpp
@@ -21,7 +21,6 @@
 
 #include <optional>
 #include <string_view>
-#include <utility>
 
 namespace sudoku::engine {
 
@@ -76,7 +75,7 @@ std::expected<ReconstructedState, ReconstructError> reconstruct(const Reconstruc
         candidates.eliminateCandidate(elim.position.row, elim.position.col, elim.value);
     }
 
-    return ReconstructedState{parsed.value(), std::move(candidates)};
+    return ReconstructedState{.board = parsed.value(), .candidates = candidates};
 }
 
 }  // namespace sudoku::engine

--- a/src/core/reconstruction.cpp
+++ b/src/core/reconstruction.cpp
@@ -1,0 +1,82 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "reconstruction.h"
+
+#include "core/constants.h"
+#include "game_validator.h"
+
+#include <optional>
+#include <string_view>
+#include <utility>
+
+namespace sudoku::engine {
+
+namespace {
+
+/// Parse a flat 81-char board ('0'/'.' = empty, '1'-'9' = value) into a BoardData.
+/// Dependency-free by design (Option B): avoids PuzzleAnalyzer's three-dependency
+/// constructor so this engine keystone stays lightweight and reentrant. Returns
+/// nullopt on wrong length or an illegal character (surfaced as ParseFailed).
+[[nodiscard]] std::optional<core::BoardData> parseFlatBoard(std::string_view flat) {
+    if (flat.size() != core::TOTAL_CELLS) {
+        return std::nullopt;
+    }
+    core::BoardData board;
+    for (size_t i = 0; i < core::TOTAL_CELLS; ++i) {
+        const char ch = flat[i];
+        if (ch == '.' || ch == '0') {
+            board[i / core::BOARD_SIZE][i % core::BOARD_SIZE] = core::EMPTY_CELL;
+        } else if (ch >= '1' && ch <= '9') {
+            board[i / core::BOARD_SIZE][i % core::BOARD_SIZE] = ch - '0';
+        } else {
+            return std::nullopt;
+        }
+    }
+    return board;
+}
+
+}  // namespace
+
+std::expected<ReconstructedState, ReconstructError> reconstruct(const ReconstructionInput& input) {
+    const auto parsed = parseFlatBoard(input.board_at_step);
+    if (!parsed.has_value()) {
+        return std::unexpected(ReconstructError::ParseFailed);
+    }
+
+    const core::GameValidator validator;
+    if (!validator.validateBoard(parsed.value())) {
+        return std::unexpected(ReconstructError::InvalidBoard);
+    }
+
+    // Replay each prior elimination onto the base candidate set. CandidateGrid's
+    // overlay is monotonic (no un-eliminate), which is exactly what replay needs.
+    // Range-check every entry first: eliminateCandidate indexes an 81-element array
+    // and shifts by `value`, so an out-of-range (e.g. deserialized) entry would be
+    // out-of-bounds / shift UB — surface it as a clean error instead.
+    core::CandidateGrid candidates(parsed.value());
+    for (const auto& elim : input.prior_eliminations) {
+        if (elim.position.row >= core::BOARD_SIZE || elim.position.col >= core::BOARD_SIZE ||
+            elim.value < core::MIN_VALUE || elim.value > core::MAX_VALUE) {
+            return std::unexpected(ReconstructError::InvalidElimination);
+        }
+        candidates.eliminateCandidate(elim.position.row, elim.position.col, elim.value);
+    }
+
+    return ReconstructedState{parsed.value(), std::move(candidates)};
+}
+
+}  // namespace sudoku::engine

--- a/src/core/reconstruction.h
+++ b/src/core/reconstruction.h
@@ -1,0 +1,68 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "candidate_grid.h"   // core::CandidateGrid
+#include "core/board_data.h"  // core::BoardData
+#include "solve_step.h"       // core::Elimination
+
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <vector>
+
+// NOTE (Wave-1 straddle): this file lives physically in src/core/ but declares
+// namespace sudoku::engine on purpose (DEC-1). Phase A E1 encloses it into the
+// sudoku_engine target and E3 relocates it to include/engine/ mechanically. Do
+// not "fix" the namespace to match the directory. It must stay Qt-free,
+// spdlog-free, and own no global/function-local static mutable state.
+namespace sudoku::engine {
+
+/// POD input to reconstruct(): a starting board (flat 81-char string) plus the
+/// prior candidate eliminations to replay onto its base candidate set. Reuses
+/// the existing core::Elimination representation — never invent a parallel one.
+struct ReconstructionInput {
+    std::string board_at_step;                          ///< flat 81-char board ('0'/'.' = empty)
+    std::vector<core::Elimination> prior_eliminations;  ///< eliminations to replay onto the base set
+};
+
+/// A successfully reconstructed state: the parsed board and the candidate grid
+/// with every prior elimination applied. Structured data only — no localized text.
+struct ReconstructedState {
+    core::BoardData board;
+    core::CandidateGrid candidates;
+};
+
+/// Failure modes surfaced through the std::expected error channel (never thrown).
+enum class ReconstructError : std::uint8_t {
+    InvalidBoard,        ///< board_at_step parsed but violates Sudoku validity
+    ParseFailed,         ///< board_at_step could not be parsed (bad length or illegal character)
+    InvalidElimination,  ///< a prior_eliminations entry has an out-of-range cell or value
+};
+
+/// Rebuild a (board, candidates) state from a starting board + prior eliminations.
+///
+/// Qt-free and reentrant: all scratch is stack/parameter; no cached buffers.
+///
+/// board_at_step is a flat 81-char string ('0'/'.' = empty, '1'-'9' = value); it is
+/// validated for both format (else ParseFailed) and Sudoku validity (else InvalidBoard).
+/// Every prior_eliminations entry is range-checked — row/col in [0, BOARD_SIZE) and value
+/// in [MIN_VALUE, MAX_VALUE] — so a malformed (e.g. deserialized) entry yields
+/// InvalidElimination rather than out-of-bounds/shift UB in CandidateGrid.
+[[nodiscard]] std::expected<ReconstructedState, ReconstructError> reconstruct(const ReconstructionInput& input);
+
+}  // namespace sudoku::engine

--- a/tests/unit/test_kraken_fish_strategy.cpp
+++ b/tests/unit/test_kraken_fish_strategy.cpp
@@ -16,6 +16,7 @@
 
 #include "../../src/core/candidate_grid.h"
 #include "../../src/core/puzzle_generator.h"
+#include "../../src/core/reconstruction.h"
 #include "../../src/core/strategies/forcing_chain_helpers.h"
 #include "../../src/core/strategies/kraken_fish_strategy.h"
 #include "../helpers/candidate_test_utils.h"
@@ -222,22 +223,28 @@ TEST_CASE("KrakenFishStrategy - vacuous fin contradiction reports fin-exclusion"
           "[kraken_fish][regression][issue40]") {
     constexpr std::string_view kBoardFlat =
         "050040000060005200370060008290000000005001090000030020507003004006070002000400010";
-    BoardData board = sudoku::testing::flatStringToBoard(std::string(kBoardFlat));
-    CandidateGrid state(board);
 
-    // Prior eliminations recorded in the fixture — bring the candidate grid into the
-    // same state the solver would reach by step 7.
-    state.eliminateCandidate(4, 0, 4);
-    state.eliminateCandidate(4, 0, 8);
-    state.eliminateCandidate(5, 0, 1);
-    state.eliminateCandidate(5, 0, 4);
-    state.eliminateCandidate(5, 0, 8);
-    state.eliminateCandidate(8, 2, 2);
-    state.eliminateCandidate(3, 6, 5);
-    state.eliminateCandidate(3, 7, 5);
-    state.eliminateCandidate(6, 4, 8);
-    state.eliminateCandidate(0, 3, 1);
-    state.eliminateCandidate(1, 3, 1);
+    // Prior eliminations recorded in the fixture — bring the candidate grid into the same
+    // state the solver would reach by step 7. Reconstructed via the shared engine primitive
+    // (Story A.0) instead of inline eliminateCandidate calls: a free proof (AC4) that the
+    // extraction is behavior-identical to the hand-written replay it replaced.
+    const auto reconstructed = sudoku::engine::reconstruct({.board_at_step = std::string(kBoardFlat),
+                                                            .prior_eliminations = {
+                                                                {{.row = 4, .col = 0}, 4},
+                                                                {{.row = 4, .col = 0}, 8},
+                                                                {{.row = 5, .col = 0}, 1},
+                                                                {{.row = 5, .col = 0}, 4},
+                                                                {{.row = 5, .col = 0}, 8},
+                                                                {{.row = 8, .col = 2}, 2},
+                                                                {{.row = 3, .col = 6}, 5},
+                                                                {{.row = 3, .col = 7}, 5},
+                                                                {{.row = 6, .col = 4}, 8},
+                                                                {{.row = 0, .col = 3}, 1},
+                                                                {{.row = 1, .col = 3}, 1},
+                                                            }});
+    REQUIRE(reconstructed.has_value());
+    const BoardData& board = reconstructed->board;
+    CandidateGrid state = reconstructed->candidates;
 
     KrakenFishStrategy strategy;
     auto result = strategy.findStep(board, state);

--- a/tests/unit/test_kraken_fish_strategy.cpp
+++ b/tests/unit/test_kraken_fish_strategy.cpp
@@ -230,17 +230,17 @@ TEST_CASE("KrakenFishStrategy - vacuous fin contradiction reports fin-exclusion"
     // extraction is behavior-identical to the hand-written replay it replaced.
     const auto reconstructed = sudoku::engine::reconstruct({.board_at_step = std::string(kBoardFlat),
                                                             .prior_eliminations = {
-                                                                {{.row = 4, .col = 0}, 4},
-                                                                {{.row = 4, .col = 0}, 8},
-                                                                {{.row = 5, .col = 0}, 1},
-                                                                {{.row = 5, .col = 0}, 4},
-                                                                {{.row = 5, .col = 0}, 8},
-                                                                {{.row = 8, .col = 2}, 2},
-                                                                {{.row = 3, .col = 6}, 5},
-                                                                {{.row = 3, .col = 7}, 5},
-                                                                {{.row = 6, .col = 4}, 8},
-                                                                {{.row = 0, .col = 3}, 1},
-                                                                {{.row = 1, .col = 3}, 1},
+                                                                {.position = {.row = 4, .col = 0}, .value = 4},
+                                                                {.position = {.row = 4, .col = 0}, .value = 8},
+                                                                {.position = {.row = 5, .col = 0}, .value = 1},
+                                                                {.position = {.row = 5, .col = 0}, .value = 4},
+                                                                {.position = {.row = 5, .col = 0}, .value = 8},
+                                                                {.position = {.row = 8, .col = 2}, .value = 2},
+                                                                {.position = {.row = 3, .col = 6}, .value = 5},
+                                                                {.position = {.row = 3, .col = 7}, .value = 5},
+                                                                {.position = {.row = 6, .col = 4}, .value = 8},
+                                                                {.position = {.row = 0, .col = 3}, .value = 1},
+                                                                {.position = {.row = 1, .col = 3}, .value = 1},
                                                             }});
     REQUIRE(reconstructed.has_value());
     const BoardData& board = reconstructed->board;

--- a/tests/unit/test_reconstruction.cpp
+++ b/tests/unit/test_reconstruction.cpp
@@ -47,6 +47,7 @@ constexpr std::string_view kValidBoard = "530070000"
 
 }  // namespace
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE; the 81-cell no-other-change sweep is inherent to the assertion.
 TEST_CASE("Reconstruct_AppliesPriorEliminationsToBaseCandidates", "[reconstruction][engine]") {
     // Arrange
     const core::BoardData expected_board = testing::flatStringToBoard(std::string(kValidBoard));
@@ -120,6 +121,7 @@ TEST_CASE("Reconstruct_RejectsInvalidBoard", "[reconstruction][engine]") {
     CHECK(result.error() == engine::ReconstructError::InvalidBoard);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — Catch2 TEST_CASE with multiple SECTIONs; complexity is inherent to the case matrix.
 TEST_CASE("Reconstruct_RejectsOutOfRangeElimination", "[reconstruction][engine]") {
     // A malformed prior-elimination entry must surface as InvalidElimination rather than
     // being silently applied (an out-of-range value sets a wrong/unused candidate bit) or,

--- a/tests/unit/test_reconstruction.cpp
+++ b/tests/unit/test_reconstruction.cpp
@@ -1,0 +1,160 @@
+// sudoku - Offline Sudoku Game
+// Copyright (C) 2025-2026 Alexander Bendlin (darkstar79)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "../helpers/strategy_test_utils.h"  // sudoku::testing::flatStringToBoard
+#include "../helpers/test_utils.h"           // sudoku::test::isBoardValid
+#include "core/board_data.h"
+#include "core/candidate_grid.h"
+#include "core/constants.h"
+#include "core/reconstruction.h"
+#include "core/solve_step.h"
+
+#include <cstdint>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace sudoku;
+using sudoku::core::BOARD_SIZE;
+
+namespace {
+
+// Canonical valid puzzle (unique solution). The empty cell (0,2) has base
+// candidates {1,2,4}, so eliminating 1 and 2 leaves exactly {4} — a hand-known
+// two-elimination case (guarded by the isAllowed preconditions below).
+constexpr std::string_view kValidBoard = "530070000"
+                                         "600195000"
+                                         "098000060"
+                                         "800060003"
+                                         "400803001"
+                                         "700020006"
+                                         "060000280"
+                                         "000419005"
+                                         "000080079";
+
+}  // namespace
+
+TEST_CASE("Reconstruct_AppliesPriorEliminationsToBaseCandidates", "[reconstruction][engine]") {
+    // Arrange
+    const core::BoardData expected_board = testing::flatStringToBoard(std::string(kValidBoard));
+    REQUIRE(sudoku::test::isBoardValid(expected_board));  // U-VALID precondition
+
+    // The eliminations must be candidates in the fresh base grid, else the case
+    // is fabricated — assert that up front so a wrong board fails loudly here.
+    const core::CandidateGrid baseline(expected_board);
+    constexpr size_t kRow = 0;
+    constexpr size_t kCol = 2;
+    REQUIRE(baseline.isAllowed(kRow, kCol, 1));
+    REQUIRE(baseline.isAllowed(kRow, kCol, 2));
+
+    const engine::ReconstructionInput input{
+        .board_at_step = std::string(kValidBoard),
+        .prior_eliminations =
+            {
+                core::Elimination{.position = core::Position{.row = kRow, .col = kCol}, .value = 1},
+                core::Elimination{.position = core::Position{.row = kRow, .col = kCol}, .value = 2},
+            },
+    };
+
+    // Act
+    const auto result = engine::reconstruct(input);
+
+    // Assert
+    REQUIRE(result.has_value());
+    const auto& state = result.value();
+
+    // The board round-trips to the parsed input.
+    CHECK(state.board == expected_board);
+
+    // Exactly the two named candidates are gone at (0,2); nothing else there.
+    CHECK_FALSE(state.candidates.isAllowed(kRow, kCol, 1));
+    CHECK_FALSE(state.candidates.isAllowed(kRow, kCol, 2));
+    const auto removed_bits = static_cast<uint16_t>((1U << 1U) | (1U << 2U));
+    const auto expected_cell_mask = static_cast<uint16_t>(baseline.getPossibleValuesMask(kRow, kCol) & ~removed_bits);
+    CHECK(state.candidates.getPossibleValuesMask(kRow, kCol) == expected_cell_mask);
+
+    // No other cell changed versus a fresh baseline grid.
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            if (r == kRow && c == kCol) {
+                continue;
+            }
+            CHECK(state.candidates.getPossibleValuesMask(r, c) == baseline.getPossibleValuesMask(r, c));
+        }
+    }
+}
+
+TEST_CASE("Reconstruct_RejectsInvalidBoard", "[reconstruction][engine]") {
+    // Arrange: a duplicate 5 in row 0 makes the board fail validity.
+    const engine::ReconstructionInput input{
+        .board_at_step = "550070000"
+                         "600195000"
+                         "098000060"
+                         "800060003"
+                         "400803001"
+                         "700020006"
+                         "060000280"
+                         "000419005"
+                         "000080079",
+        .prior_eliminations = {},
+    };
+
+    // Act
+    const auto result = engine::reconstruct(input);
+
+    // Assert
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error() == engine::ReconstructError::InvalidBoard);
+}
+
+TEST_CASE("Reconstruct_RejectsOutOfRangeElimination", "[reconstruction][engine]") {
+    // A malformed prior-elimination entry must surface as InvalidElimination rather than
+    // being silently applied (an out-of-range value sets a wrong/unused candidate bit) or,
+    // worse, driving an out-of-bounds write / shift-UB inside CandidateGrid. This guards
+    // the primitive's future consumers (A.3 fixture replay, C.1 pool loader) that feed it
+    // deserialized data.
+    auto with_elim = [](const core::Elimination& elim) {
+        return engine::ReconstructionInput{.board_at_step = std::string(kValidBoard), .prior_eliminations = {elim}};
+    };
+
+    SECTION("value below MIN_VALUE") {
+        const auto result =
+            engine::reconstruct(with_elim({.position = core::Position{.row = 0, .col = 2}, .value = 0}));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error() == engine::ReconstructError::InvalidElimination);
+    }
+
+    SECTION("value above MAX_VALUE") {
+        const auto result =
+            engine::reconstruct(with_elim({.position = core::Position{.row = 0, .col = 2}, .value = 10}));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error() == engine::ReconstructError::InvalidElimination);
+    }
+
+    SECTION("row out of range") {
+        const auto result =
+            engine::reconstruct(with_elim({.position = core::Position{.row = BOARD_SIZE, .col = 0}, .value = 1}));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error() == engine::ReconstructError::InvalidElimination);
+    }
+
+    SECTION("col out of range") {
+        const auto result =
+            engine::reconstruct(with_elim({.position = core::Position{.row = 0, .col = BOARD_SIZE}, .value = 1}));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error() == engine::ReconstructError::InvalidElimination);
+    }
+}


### PR DESCRIPTION
## What & why

Introduces a Qt-free, reentrant **`sudoku::engine::reconstruct()`** that rebuilds a `(board, candidates)` state from a flat 81-char board string plus prior candidate eliminations.

This is the corpus-plan **keystone (Story A.0, DEC-1)** — the single shared home for reconstruction math previously open-coded in the fixture generator and the Kraken Fish test. It's the dependency root for **A.3** (fixture replay adapter) and **C.1** (training-pool loader), extracted once now so those don't duplicate it. First post-1.0.0 branch (Phase A engine-extraction is sequenced after the 1.0.0 tag; this Wave-1 primitive is test-harness-facing and ships no user change).

## Design notes

- **POD in / structured out.** `ReconstructionInput` (flat board + `std::vector<core::Elimination>`, reusing the existing core type) → `ReconstructedState { BoardData; CandidateGrid }`. No localized text crosses the API.
- **Dependency-free parse (Option B, maintainer-approved).** Uses an inline `parseFlatBoard` + `GameValidator::validateBoard` instead of `PuzzleAnalyzer::parseString`, whose sole constructor requires three non-null deps (validator + solver + counter) — too heavy for a lightweight engine keystone. Trade-off: `parseFlatBoard` has a *narrower* accept-set (flat-81 only; no whitespace/`'_'`), which A.3/C.1 must respect when serializing board fields.
- **Wave-1 straddle.** Physically in `src/core/` but declares `namespace sudoku::engine`, so the later **E1** library enclosure and **E3** `core→engine` rename sweep it with zero rework.

## Error channel

`std::expected<ReconstructedState, ReconstructError>` — `ParseFailed` (bad length/char), `InvalidBoard` (fails Sudoku validity), and `InvalidElimination` (out-of-range `prior_eliminations` entry).

## Review & hardening

An adversarial BMAD code review (Blind Hunter / Edge Case Hunter / Acceptance Auditor) ran against the diff — verdict *fix-then-ship*. Its one substantive finding is fixed here: the replay loop previously trusted every elimination entry, so an out-of-range `row`/`col`/`value` was out-of-bounds/shift UB inside `CandidateGrid::eliminateCandidate`. Now each entry is range-checked → `InvalidElimination`, so a malformed/deserialized entry (the exact case A.3/C.1 introduce) is a clean error. The two remaining findings were documentation/AC-wording, reconciled in the story record.

## Testing

- New `tests/unit/test_reconstruction.cpp` (`[reconstruction][engine]`) — RED-first: applies-eliminations happy path (exact-diff assertion + full 81-cell no-other-change sweep), `InvalidBoard`, and `InvalidElimination` (value<1, value>9, row-OOB, col-OOB).
- Repoints the issue-#40 Kraken Fish test's 11 inline eliminations onto the shared primitive (AC4 behaviour-identical proof; all 11 verified transcribed exactly).
- Full suite green: unit **1074 cases / 15812 assertions**, integration 14, offscreen UI 13/13. Format + determinism clean.

No CHANGELOG entry — internal test-harness primitive, not user- or packager-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)