### PR TITLE
fix(save): range-validate numeric save-file fields on load (7-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ First tagged release (in preparation). Adds the custom-puzzle feature suite on t
 ### Security
 
 - **Save-file decompression is now capped at 64 MiB.** Previously the zlib decompression loop could allocate up to ~4096× the compressed input before giving up — a crafted 10 MiB save file could demand ~40 GiB of RAM and crash the process via OOM. The cap is far above any realistic save (YAML saves are typically <1 MiB) but small enough to keep the decompressor's memory bounded; oversized inputs are now rejected with `CompressionError`. Affects both regular save loading and `importSave`. (#12)
+- **Numeric fields in a save file are now range-validated on load.** A hand-edited or otherwise malformed save could previously carry out-of-range move positions, cell values, or note values that the loader accepted (it checked only board *dimensions*, not the numbers inside); the bad values could then cause an out-of-bounds write when you undid/redid a move, or trigger undefined behavior. Every numeric field — move row/column/value/type, the move index, board cells, and pencil-mark values — is now checked against the board's fixed range at load time, and a save that violates it is refused as invalid data rather than mishandled. A rejected file is preserved aside, never overwritten. Legitimate saves are unaffected and the save format is unchanged (`SAVE_FILE_VERSION` 1.1).
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,8 @@ sudoku is an offline desktop application. It has no network-facing components, n
 - **Save file parsing** (YAML + zlib + libsodium decryption)
 - **Local file I/O** (save/load, statistics, configuration)
 
+Save files are treated as untrusted input: every numeric field the loader reads (move positions, move values, cell values, note values, move type, and the move index) is range-validated against the board's fixed domain at the deserializer boundary. A save with an out-of-range field is rejected as invalid data — and preserved aside, never mishandled on undo/redo or overwritten.
+
 ## Reporting a Vulnerability
 
 All security issues can be reported publicly via [GitHub Issues](../../issues).

--- a/src/core/save_manager_serialization.cpp
+++ b/src/core/save_manager_serialization.cpp
@@ -372,8 +372,45 @@ std::expected<SavedGame, SaveError> SaveManager::deserializeFromYaml(const std::
         // Current state
         BoardSerializer::deserializeIntBoard(puzzle_data["current_state"], game.current_state);
 
+        // Range-validate every deserialized cell (Story 7.1). The dimension checks above prove the
+        // board is 9×9 but not that its numbers are in [EMPTY_CELL, MAX_VALUE]; an out-of-domain cell
+        // would later reach valueToBit() == (1 << value) from the solver → shift-UB. Reject at the
+        // deserializer boundary, the same as the dimension checks.
+        for (size_t r = 0; r < BOARD_SIZE; ++r) {
+            for (size_t c = 0; c < BOARD_SIZE; ++c) {
+                if (game.original_puzzle[r][c] < EMPTY_CELL || game.original_puzzle[r][c] > MAX_VALUE ||
+                    game.current_state[r][c] < EMPTY_CELL || game.current_state[r][c] > MAX_VALUE) {
+                    spdlog::error("Invalid cell value in save at ({}, {}): original={}, current={}", r, c,
+                                  game.original_puzzle[r][c], game.current_state[r][c]);
+                    return std::unexpected(SaveError::InvalidSaveData);
+                }
+            }
+        }
+
         // Notes
         if (puzzle_data["notes"]) {
+            // Range-validate note values BEFORE deserialization (V2, Story 7.1). Each note reaches
+            // CellNotes::add → valueToBit(value) == (1 << value), which is UB for value < MIN_VALUE or
+            // >= 32. Contract (Dev Notes AC3) = REJECT the whole save at the boundary rather than skip,
+            // so a hostile save never silently loads with dropped notes. deserializeNotes stays void.
+            const auto& notes_node = puzzle_data["notes"];
+            for (size_t r = 0; r < BOARD_SIZE; ++r) {
+                if (!notes_node[r]) {
+                    continue;
+                }
+                for (size_t c = 0; c < BOARD_SIZE; ++c) {
+                    if (!notes_node[r][c]) {
+                        continue;
+                    }
+                    for (const auto& note : notes_node[r][c]) {
+                        const int note_val = note.as<int>();
+                        if (note_val < MIN_VALUE || note_val > MAX_VALUE) {
+                            spdlog::error("Invalid note value in save at ({}, {}): {}", r, c, note_val);
+                            return std::unexpected(SaveError::InvalidSaveData);
+                        }
+                    }
+                }
+            }
             BoardSerializer::deserializeNotes(puzzle_data["notes"], game.notes);
         }
 
@@ -409,10 +446,45 @@ std::expected<SavedGame, SaveError> SaveManager::deserializeFromYaml(const std::
             const auto& move_history = root["move_history"];
             for (const auto& yaml_move : move_history) {
                 Move move;
-                move.position.row = yaml_move["row"].as<int>();
-                move.position.col = yaml_move["col"].as<int>();
-                move.value = yaml_move["value"].as<int>();
-                move.move_type = static_cast<MoveType>(yaml_move["type"].as<int>());
+
+                // Range-validate every numeric field BEFORE it is stored or replayed (Story 7.1). A
+                // crafted save is untrusted input per SECURITY.md; an out-of-domain row/col/value/type
+                // would otherwise reach the GameState::setValue/setNotes sinks on undo/redo and index
+                // out of bounds. Read row/col as SIGNED ints and check both ends so a YAML "-1" is
+                // caught before it narrows to a huge size_t. Mirrors reconstruction.cpp:69-76.
+                const int row = yaml_move["row"].as<int>();
+                const int col = yaml_move["col"].as<int>();
+                const int value = yaml_move["value"].as<int>();
+                const int type = yaml_move["type"].as<int>();
+
+                if (row < 0 || col < 0 || std::cmp_greater_equal(row, BOARD_SIZE) ||
+                    std::cmp_greater_equal(col, BOARD_SIZE)) {
+                    spdlog::error("Invalid move position in save: ({}, {})", row, col);
+                    return std::unexpected(SaveError::InvalidSaveData);
+                }
+                if (value < EMPTY_CELL || value > MAX_VALUE) {
+                    spdlog::error("Invalid move value in save: {}", value);
+                    return std::unexpected(SaveError::InvalidSaveData);
+                }
+                // Validate the raw int is a defined MoveType enumerator before the cast, mirroring the
+                // origin switch-with-default idiom above. Undefined enum values are rejected, not
+                // silently coerced (a bad type would misdirect the undo/redo replay).
+                switch (type) {
+                    case static_cast<int>(MoveType::PlaceNumber):
+                    case static_cast<int>(MoveType::RemoveNumber):
+                    case static_cast<int>(MoveType::AddNote):
+                    case static_cast<int>(MoveType::RemoveNote):
+                    case static_cast<int>(MoveType::PlaceHint):
+                        move.move_type = static_cast<MoveType>(type);
+                        break;
+                    default:
+                        spdlog::error("Invalid move type in save: {}", type);
+                        return std::unexpected(SaveError::InvalidSaveData);
+                }
+
+                move.position.row = static_cast<size_t>(row);
+                move.position.col = static_cast<size_t>(col);
+                move.value = value;
                 move.is_note = yaml_move["is_note"].as<bool>();
 
                 // #24 M4: Move::timestamp removed. Older snapshots may still carry a "timestamp"
@@ -422,7 +494,15 @@ std::expected<SavedGame, SaveError> SaveManager::deserializeFromYaml(const std::
             }
 
             if (root["current_move_index"]) {
-                game.current_move_index = root["current_move_index"].as<int>();
+                const int index = root["current_move_index"].as<int>();
+                // Valid range is [-1, size-1]: -1 means "all moves undone", otherwise it points at a
+                // real move. An out-of-range index would let redo walk past move_history's end.
+                if (index < -1 || std::cmp_greater_equal(index, game.move_history.size())) {
+                    spdlog::error("Invalid current_move_index in save: {} (history size {})", index,
+                                  game.move_history.size());
+                    return std::unexpected(SaveError::InvalidSaveData);
+                }
+                game.current_move_index = index;
             }
         }
 

--- a/src/model/game_state.cpp
+++ b/src/model/game_state.cpp
@@ -161,8 +161,14 @@ core::BoardData GameState::extractGivenNumbers() const {
 // Per-cell value access
 
 void GameState::setValue(size_t row, size_t col, int value) {
-    values_[row][col] = value;
-    markDirty();
+    // Bounds guard (Story 7.1, defense in depth) — match the sibling addNote/removeNote setters so an
+    // out-of-range position from any caller (e.g. a replayed move from a hostile save) is a no-op
+    // rather than an out-of-bounds write. The (Position, value) overload delegates here, so it is
+    // covered too. Load-time validation is the primary defense; this is belt-and-suspenders.
+    if (row < core::BOARD_SIZE && col < core::BOARD_SIZE) {
+        values_[row][col] = value;
+        markDirty();
+    }
 }
 
 void GameState::setValue(const core::Position& pos, int value) {
@@ -205,8 +211,11 @@ void GameState::setHintRevealed(const core::Position& pos, bool revealed) {
 // Per-cell notes access
 
 void GameState::setNotes(const core::Position& pos, const core::CellNotes& notes) {
-    notes_data_[pos.row][pos.col] = notes;
-    markDirty();
+    // Bounds guard (Story 7.1, defense in depth) — see setValue above.
+    if (pos.row < core::BOARD_SIZE && pos.col < core::BOARD_SIZE) {
+        notes_data_[pos.row][pos.col] = notes;
+        markDirty();
+    }
 }
 
 const core::CellNotes& GameState::getNotes(size_t row, size_t col) const {

--- a/tests/unit/test_save_manager_persistence_hardening.cpp
+++ b/tests/unit/test_save_manager_persistence_hardening.cpp
@@ -26,8 +26,10 @@
 #include "../../src/core/save_manager.h"
 #include "../helpers/test_utils.h"
 
+#include <expected>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iterator>
 #include <random>
 #include <string>
@@ -35,6 +37,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <yaml-cpp/yaml.h>
 
 using namespace sudoku::core;
 using sudoku::test::TempTestDir;
@@ -195,4 +198,168 @@ TEST_CASE("SaveManager - corrupt save is archived aside and never overwritten",
     std::ifstream in(archives.front());
     const std::string archived((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     REQUIRE(archived == corrupt_bytes);
+}
+
+// ── Story 7.1: malicious numeric-field hardening ───────────────────────────────────────────────
+//
+// The deserializer historically validated board *dimensions* (9×9) but trusted the numeric *values*
+// inside — so a save with a plausible board plus one out-of-domain field (move row 40, note 99, cell
+// 200, …) loaded successfully and then drove an out-of-bounds write on the next undo/redo through the
+// unchecked GameState::setValue/setNotes sinks, or shift-UB via valueToBit. These cases poison exactly
+// one field of an otherwise-valid save and assert loadGame refuses it as InvalidSaveData at the parse
+// boundary. Authored RED-first: against the pre-fix parser every case *wrongly accepts* (loadGame
+// returns a value), and the note/cell cases additionally fire ASan/UBSan — precisely the bug.
+
+namespace {
+
+// A minimal but fully in-domain SavedGame with one legitimate PlaceNumber move. save_id is fixed so
+// the on-disk file path is deterministic (getSavePath = dir / (save_id + ".yaml")).
+SavedGame makeValidGameWithMove() {
+    SavedGame game;
+    game.save_id = "victim";
+    game.display_name = "Victim";
+    game.difficulty = Difficulty::Easy;
+    for (size_t r = 0; r < BOARD_SIZE; ++r) {
+        for (size_t c = 0; c < BOARD_SIZE; ++c) {
+            game.original_puzzle[r][c] = EMPTY_CELL;
+            game.current_state[r][c] = EMPTY_CELL;
+        }
+    }
+    game.current_state[0][0] = MAX_VALUE;  // one in-range filled cell
+
+    Move move;
+    move.position = {.row = 0, .col = 0};
+    move.value = MAX_VALUE;
+    move.move_type = MoveType::PlaceNumber;
+    move.is_note = false;
+    game.move_history.push_back(move);
+    game.current_move_index = 0;
+
+    return game;
+}
+
+// Save `game` uncompressed/unencrypted (so the file is plaintext YAML), mutate the on-disk node with
+// `poison`, write it back, then load it. Returns whatever loadGame returns so the caller can assert on
+// the rejection.
+std::expected<SavedGame, SaveError> poisonRoundTrip(SaveManager& mgr, const fs::path& dir, const SavedGame& game,
+                                                    const std::function<void(YAML::Node&)>& poison) {
+    SaveSettings settings;
+    settings.compress = false;
+    settings.include_history = true;
+
+    auto id = mgr.saveGame(game, settings);
+    REQUIRE(id.has_value());
+
+    const auto path = dir / (*id + ".yaml");
+    YAML::Node root = YAML::LoadFile(path.string());
+    poison(root);
+    {
+        std::ofstream out(path, std::ios::trunc);
+        out << root;
+    }
+    return mgr.loadGame(*id);
+}
+
+}  // namespace
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
+TEST_CASE("SaveManager - malicious save with out-of-range move row is rejected",
+          "[save_manager][persistence][security][regression][bug-save-oob]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // row 40 ≫ BOARD_SIZE: on the pre-fix code this loads, then Undo(revertMove) → setValue indexes
+    // values_[40][0] → OOB write.
+    auto result = poisonRoundTrip(mgr, tmp.path(), makeValidGameWithMove(),
+                                  [](YAML::Node& root) { root["move_history"][0]["row"] = 40; });
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == SaveError::InvalidSaveData);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
+TEST_CASE("SaveManager - malicious save with negative move row is rejected",
+          "[save_manager][persistence][security][regression][bug-save-oob]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // row -1 read as int then assigned to size_t wraps to 18446744073709551615 → OOB. Must be caught
+    // by an explicit signed-range check before the narrowing.
+    auto result = poisonRoundTrip(mgr, tmp.path(), makeValidGameWithMove(),
+                                  [](YAML::Node& root) { root["move_history"][0]["row"] = -1; });
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == SaveError::InvalidSaveData);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
+TEST_CASE("SaveManager - malicious save with out-of-range note value is rejected",
+          "[save_manager][persistence][security][regression][bug-save-oob]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // note 99 reaches CellNotes::add → valueToBit(99) = 1 << 99 → shift-UB (V2). UBSan fires on the
+    // pre-fix code; the fix rejects the value at the deserializer boundary.
+    auto result = poisonRoundTrip(mgr, tmp.path(), makeValidGameWithMove(),
+                                  [](YAML::Node& root) { root["puzzle_data"]["notes"][0][0][0] = 99; });
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == SaveError::InvalidSaveData);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
+TEST_CASE("SaveManager - malicious save with out-of-range cell value is rejected",
+          "[save_manager][persistence][security][regression][bug-save-oob]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // cell 200 is outside [EMPTY_CELL, MAX_VALUE]; later valueToBit(200) from the solver = shift-UB.
+    auto result = poisonRoundTrip(mgr, tmp.path(), makeValidGameWithMove(),
+                                  [](YAML::Node& root) { root["puzzle_data"]["current_state"][0][0] = 200; });
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == SaveError::InvalidSaveData);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
+TEST_CASE("SaveManager - malicious save with out-of-range move type is rejected",
+          "[save_manager][persistence][security][regression][bug-save-oob]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // type 99 is not a defined MoveType enumerator; static_cast<MoveType>(99) then a replay switch is
+    // undefined territory. Reject at load.
+    auto result = poisonRoundTrip(mgr, tmp.path(), makeValidGameWithMove(),
+                                  [](YAML::Node& root) { root["move_history"][0]["type"] = 99; });
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == SaveError::InvalidSaveData);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
+TEST_CASE("SaveManager - malicious save with out-of-range move column is rejected",
+          "[save_manager][persistence][security][regression][bug-save-oob]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // Poison the column (not the row) so both position axes are covered by the regression net.
+    auto result = poisonRoundTrip(mgr, tmp.path(), makeValidGameWithMove(),
+                                  [](YAML::Node& root) { root["move_history"][0]["col"] = 40; });
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == SaveError::InvalidSaveData);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
+TEST_CASE("SaveManager - malicious save with out-of-range current_move_index is rejected",
+          "[save_manager][persistence][security][regression][bug-save-oob]") {
+    TempTestDir tmp;
+    SaveManager mgr(tmp.path().string());
+
+    // History has exactly one move (valid indices are -1 and 0); 5 points past its end.
+    auto result = poisonRoundTrip(mgr, tmp.path(), makeValidGameWithMove(),
+                                  [](YAML::Node& root) { root["current_move_index"] = 5; });
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == SaveError::InvalidSaveData);
 }


### PR DESCRIPTION
## Summary

Epic 7 (Security Hardening) **keystone** — closes the one real memory-corruption bug from the 2026-07-06 security audit.

The save deserializer validated board *dimensions* (9×9) but trusted the *numbers* inside, so a hand-edited or malicious save with an out-of-range field loaded successfully and then caused:
- **V1 — out-of-bounds write** on the next undo/redo, through the unchecked `GameState::setValue`/`setNotes` sinks; and
- **V2 — shift-UB** via `valueToBit` (`1 << value`) when a bad note/cell value reached `CellNotes::add`.

A crafted save is untrusted input per [SECURITY.md](../blob/main/SECURITY.md)'s own threat model (save-file parsing is the primary attack surface).

## What changed

Range-validate **every** numeric field the loader reads, at the deserializer boundary, rejecting bad saves with `SaveError::InvalidSaveData`:
- **Move history** — `row`/`col` (read as signed int, checked `< 0` *before* the `size_t` narrowing), `value ∈ [EMPTY_CELL, MAX_VALUE]`, `type` is a defined `MoveType` enumerator (switch-with-default), and `current_move_index ∈ [-1, size-1]`.
- **Both boards** — every cell `∈ [EMPTY_CELL, MAX_VALUE]`.
- **Note values** — `∈ [MIN_VALUE, MAX_VALUE]`, validated in the caller (`deserializeFromYaml`) *before* `deserializeNotes` runs, so `valueToBit` never sees a bad value (`deserializeNotes` keeps its `void` signature).
- **Defense-in-depth** — bounds guards on `GameState::setValue`/`setNotes`, matching the sibling `addNote`/`removeNote` setters.

`SAVE_FILE_VERSION` stays **1.1** — no format change, no migration, no public-API change. A rejected save is preserved aside by the existing corrupt-archive path, never overwritten.

## Testing

- **7 RED-first malicious-save cases** (`[bug-save-oob]`) in `test_save_manager_persistence_hardening.cpp`: move `row 40`/`row -1`/`col 40`, note `99`, cell `200`, bad move `type`, out-of-range `current_move_index`. Proven RED against baseline `88f5050` (each wrongly-accepted the poisoned save), now GREEN.
- Existing randomized round-trip + corrupt-archive cases stay green.
- **Clean under ASan+UBSan** (`-DENABLE_SANITIZERS=ON`, `-fno-sanitize-recover=all`) — no shift-UB or OOB fires.
- Full suites green: unit **1151** / integration **25** / UI **18**; format, determinism gate, and clang-tidy all clean.

## Review

An independent adversarial review pass found **no HIGH/MED defects** (bypass gaps, validation/consumption mismatches, narrowing correctness, regressions all checked) and verdict *safe to merge*. Its one actionable note — a thin test matrix — was addressed by adding the `col` and `current_move_index` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)