### PR TITLE
build(tooling): gate tidy-diff on exit code, not grepped message text

### DIFF
--- a/scripts/tidy-diff.sh
+++ b/scripts/tidy-diff.sh
@@ -93,40 +93,54 @@ fi
 CHANGED=$(echo "$DIFF" | grep '^+++ b/' | sed 's|^+++ b/||' | grep -E '\.(cpp|h|hpp)$' | wc -l)
 echo -e "${YELLOW}[tidy-diff] Checking $CHANGED file(s) — $MODE...${NC}"
 
-# Capture via a file rather than $(...) so output written directly by the parallel
-# clang-tidy children lands in the same place as the driver's own output.
-TIDY_LOG=$(mktemp -t tidy-diff.XXXXXX)
-trap 'rm -f "$TIDY_LOG"' EXIT
+# Gate on the EXIT CODE, exactly as the CI job does (.github/workflows/ci.yml,
+# "Run clang-tidy on changed lines").
+#
+# clang-tidy exits 0 even when it reports findings, so the flag has to be forced on.
+# clang-tidy-diff.py forwards only a fixed set of flags and rejects an explicit
+# -warnings-as-errors, hence the binary shim -- same trick, same reason, as CI.
+# clang-tidy-diff.py then returns non-zero if ANY child failed, which covers findings,
+# compile errors, crashes and timeouts alike.
+#
+# Do NOT go back to grepping the output for "warning:"/"error:" to decide pass/fail:
+#   1. It cannot tell "clean" from "never analyzed" -- a translation unit that fails to
+#      COMPILE emits no findings at all, which read as success.
+#   2. `echo "$OUT" | grep -q ...` silently LOSES matches under `set -o pipefail`:
+#      grep -q exits at the first match, echo then takes SIGPIPE, and pipefail turns
+#      that successful match into a failed pipeline. It breaks once the output exceeds
+#      the 64 KiB pipe buffer -- i.e. exactly on the large diffs that matter most.
+TIDY_SHIM=$(mktemp)
+TIDY_LOG=$(mktemp)
+trap 'rm -f "$TIDY_SHIM" "$TIDY_LOG"' EXIT
 
+cat > "$TIDY_SHIM" <<SHIM
+#!/bin/sh
+exec "$TIDY_BIN" --warnings-as-errors='*' "\$@"
+SHIM
+chmod +x "$TIDY_SHIM"
+
+TIDY_RC=0
 echo "$DIFF" | python3 "$CLANG_TIDY_DIFF" \
-    -clang-tidy-binary "$TIDY_BIN" \
+    -clang-tidy-binary "$TIDY_SHIM" \
     -p1 \
     -path "$BUILD_DIR" \
-    -quiet \
-    -j "$(nproc)" > "$TIDY_LOG" 2>&1 || true
+    -j "$(nproc)" > "$TIDY_LOG" 2>&1 || TIDY_RC=$?
 
-OUTPUT=$(cat "$TIDY_LOG")
+cat "$TIDY_LOG"
 
-if [ -n "$OUTPUT" ]; then
-    echo "$OUTPUT"
-fi
-
-# A translation unit that fails to COMPILE yields no check findings at all, so a clean
-# result here means "never analyzed", not "clean". Report that as a failure: a gate that
-# could not run must never claim success -- silent vacuous passes are how a branch reaches
-# CI with errors the local gate said were absent.
-if echo "$OUTPUT" | grep -q "Found compiler error\|Error while processing"; then
-    echo -e "${RED}[tidy-diff] clang-tidy could NOT analyze -- this result is meaningless.${NC}"
-    echo -e "${RED}            At least one translation unit failed to compile, so no checks ran.${NC}"
-    echo "            Usual cause: ${BUILD_DIR}/compile_commands.json carries flags clang rejects,"
-    echo "            e.g. GCC-only warning names injected via -DCMAKE_CXX_FLAGS. Look for"
-    echo "            'unknown warning option' / 'unknown argument' above, then regenerate it:"
-    echo "              cmake --preset release"
-    exit 1
-fi
-
-if echo "$OUTPUT" | grep -q "warning:\|error:"; then
-    echo -e "${RED}[tidy-diff] Warnings found in changed lines.${NC}"
+if [ "$TIDY_RC" -ne 0 ]; then
+    echo -e "${RED}[tidy-diff] clang-tidy gate FAILED (exit ${TIDY_RC}) — this is what CI will fail on.${NC}"
+    # Only an explanatory hint; the exit code above already decided the outcome. Grep the
+    # FILE (never a pipe) so this cannot hit the SIGPIPE trap described above, and anchor
+    # at column 0 so an echoed source line containing the phrase can't masquerade as one.
+    if grep -q '^Error while processing' "$TIDY_LOG"; then
+        echo -e "${RED}            A translation unit failed to COMPILE, so checks never ran on it —${NC}"
+        echo -e "${RED}            the findings above are incomplete, not a clean bill of health.${NC}"
+        echo "            Usual cause: ${BUILD_DIR}/compile_commands.json carries flags clang"
+        echo "            rejects, e.g. GCC-only warning names from a local -DCMAKE_CXX_FLAGS"
+        echo "            workaround. Look for 'unknown warning option' / 'unknown argument'"
+        echo "            above, then regenerate it with: cmake --preset release"
+    fi
     exit 1
 fi
 

--- a/scripts/tidy-diff.sh
+++ b/scripts/tidy-diff.sh
@@ -109,15 +109,34 @@ echo -e "${YELLOW}[tidy-diff] Checking $CHANGED file(s) — $MODE...${NC}"
 #      grep -q exits at the first match, echo then takes SIGPIPE, and pipefail turns
 #      that successful match into a failed pipeline. It breaks once the output exceeds
 #      the 64 KiB pipe buffer -- i.e. exactly on the large diffs that matter most.
-TIDY_SHIM=$(mktemp)
-TIDY_LOG=$(mktemp)
+# Explicit templates: BSD/macOS mktemp requires a template or -t prefix and rejects a
+# bare invocation, and named files are identifiable when auditing TMPDIR.
+TIDY_SHIM=$(mktemp -t tidy-diff-shim.XXXXXX)
 trap 'rm -f "$TIDY_SHIM" "$TIDY_LOG"' EXIT
+TIDY_LOG=$(mktemp -t tidy-diff-log.XXXXXX)
 
-cat > "$TIDY_SHIM" <<SHIM
+# Quoted heredoc + exported variable: a TIDY_BIN path containing a quote would otherwise
+# generate a syntactically broken shim, and one containing $(...) would be evaluated when
+# the shim runs.
+cat > "$TIDY_SHIM" <<'SHIM'
 #!/bin/sh
-exec "$TIDY_BIN" --warnings-as-errors='*' "\$@"
+exec "$REAL_TIDY" --warnings-as-errors='*' "$@"
 SHIM
 chmod +x "$TIDY_SHIM"
+export REAL_TIDY="$TIDY_BIN"
+
+# The shim is a hard dependency of the gate, and clang-tidy-diff.py SWALLOWS a failure to
+# exec it: its `except Exception` handler prints "Failed: ..." but never records the file,
+# so the driver still exits 0 and every file goes unanalyzed. A noexec TMPDIR (common
+# hardening) or an SELinux/AppArmor denial would thus turn this gate into a permanent,
+# silent pass. Prove the shim actually runs before trusting anything it reports.
+if ! "$TIDY_SHIM" --version >/dev/null 2>&1; then
+    echo -e "${RED}[tidy-diff] The generated clang-tidy shim could not be executed.${NC}"
+    echo "            TMPDIR is most likely mounted noexec (or exec is blocked by"
+    echo "            SELinux/AppArmor). Re-run with a TMPDIR that permits exec:"
+    echo "              TMPDIR=\"\$(git rev-parse --show-toplevel)/build\" $0 $*"
+    exit 1
+fi
 
 TIDY_RC=0
 echo "$DIFF" | python3 "$CLANG_TIDY_DIFF" \
@@ -126,7 +145,15 @@ echo "$DIFF" | python3 "$CLANG_TIDY_DIFF" \
     -path "$BUILD_DIR" \
     -j "$(nproc)" > "$TIDY_LOG" 2>&1 || TIDY_RC=$?
 
-cat "$TIDY_LOG"
+cat "$TIDY_LOG" || true
+
+# Belt and braces for the same swallowed-launch class from any other cause (binary removed
+# mid-run, fork failure): those files were never analyzed, but the exit code alone says 0.
+if grep -q '^Failed: ' "$TIDY_LOG"; then
+    echo -e "${RED}[tidy-diff] clang-tidy could not be launched for at least one file (see${NC}"
+    echo -e "${RED}            'Failed:' above) — those files were NOT analyzed. Treating as failure.${NC}"
+    exit 1
+fi
 
 if [ "$TIDY_RC" -ne 0 ]; then
     echo -e "${RED}[tidy-diff] clang-tidy gate FAILED (exit ${TIDY_RC}) — this is what CI will fail on.${NC}"
@@ -136,10 +163,13 @@ if [ "$TIDY_RC" -ne 0 ]; then
     if grep -q '^Error while processing' "$TIDY_LOG"; then
         echo -e "${RED}            A translation unit failed to COMPILE, so checks never ran on it —${NC}"
         echo -e "${RED}            the findings above are incomplete, not a clean bill of health.${NC}"
-        echo "            Usual cause: ${BUILD_DIR}/compile_commands.json carries flags clang"
-        echo "            rejects, e.g. GCC-only warning names from a local -DCMAKE_CXX_FLAGS"
-        echo "            workaround. Look for 'unknown warning option' / 'unknown argument'"
-        echo "            above, then regenerate it with: cmake --preset release"
+        echo "            Two common causes:"
+        echo "              * A missing GENERATED source (e.g. a Qt '*.moc'): build the target"
+        echo "                first, or configure with -DSUDOKU_ENABLE_UI_TESTS=ON for UI tests."
+        echo "              * ${BUILD_DIR}/compile_commands.json carrying flags clang rejects"
+        echo "                (e.g. GCC-only warning names from a local -DCMAKE_CXX_FLAGS"
+        echo "                workaround) — look for 'unknown warning option' / 'unknown"
+        echo "                argument' above, then: cmake --preset release"
     fi
     exit 1
 fi

--- a/scripts/tidy-diff.sh
+++ b/scripts/tidy-diff.sh
@@ -93,19 +93,41 @@ fi
 CHANGED=$(echo "$DIFF" | grep '^+++ b/' | sed 's|^+++ b/||' | grep -E '\.(cpp|h|hpp)$' | wc -l)
 echo -e "${YELLOW}[tidy-diff] Checking $CHANGED file(s) — $MODE...${NC}"
 
-OUTPUT=$(echo "$DIFF" | python3 "$CLANG_TIDY_DIFF" \
+# Capture via a file rather than $(...) so output written directly by the parallel
+# clang-tidy children lands in the same place as the driver's own output.
+TIDY_LOG=$(mktemp -t tidy-diff.XXXXXX)
+trap 'rm -f "$TIDY_LOG"' EXIT
+
+echo "$DIFF" | python3 "$CLANG_TIDY_DIFF" \
     -clang-tidy-binary "$TIDY_BIN" \
     -p1 \
     -path "$BUILD_DIR" \
     -quiet \
-    -j "$(nproc)" 2>&1 || true)
+    -j "$(nproc)" > "$TIDY_LOG" 2>&1 || true
+
+OUTPUT=$(cat "$TIDY_LOG")
 
 if [ -n "$OUTPUT" ]; then
     echo "$OUTPUT"
-    if echo "$OUTPUT" | grep -q "warning:\|error:"; then
-        echo -e "${RED}[tidy-diff] Warnings found in changed lines.${NC}"
-        exit 1
-    fi
+fi
+
+# A translation unit that fails to COMPILE yields no check findings at all, so a clean
+# result here means "never analyzed", not "clean". Report that as a failure: a gate that
+# could not run must never claim success -- silent vacuous passes are how a branch reaches
+# CI with errors the local gate said were absent.
+if echo "$OUTPUT" | grep -q "Found compiler error\|Error while processing"; then
+    echo -e "${RED}[tidy-diff] clang-tidy could NOT analyze -- this result is meaningless.${NC}"
+    echo -e "${RED}            At least one translation unit failed to compile, so no checks ran.${NC}"
+    echo "            Usual cause: ${BUILD_DIR}/compile_commands.json carries flags clang rejects,"
+    echo "            e.g. GCC-only warning names injected via -DCMAKE_CXX_FLAGS. Look for"
+    echo "            'unknown warning option' / 'unknown argument' above, then regenerate it:"
+    echo "              cmake --preset release"
+    exit 1
+fi
+
+if echo "$OUTPUT" | grep -q "warning:\|error:"; then
+    echo -e "${RED}[tidy-diff] Warnings found in changed lines.${NC}"
+    exit 1
 fi
 
 echo -e "${GREEN}[tidy-diff] OK${NC}"


### PR DESCRIPTION
## The bug

`scripts/tidy-diff.sh` decided pass/fail by grepping clang-tidy's output. That is unsound in two independent ways, and the second one is severe:

**1. `echo "$OUTPUT" | grep -q` silently discards matches.** Under `set -o pipefail` (line 21), `grep -q` exits at the first hit, `echo` then takes SIGPIPE (141), and pipefail promotes that to the pipeline status — so the `if` evaluates **false precisely because it matched**. It breaks once output exceeds the 64 KiB pipe buffer, i.e. on exactly the large diffs where a missed finding costs most.

**2. Grepping cannot distinguish "clean" from "never ran."** A translation unit that fails to *compile* emits no findings at all, which reads as success.

Measured on this repo, base `HEAD~100` (397 C++ files, **477 KB** of output containing 5 `Error while processing` and 38 `warning:`/`error:` lines):

```
old logic -> both checks MISSED   => prints OK, exit 0
new logic -> exit 1
```

That is a real vacuous pass on real output, not a constructed one. It is also the most likely explanation for the vacuous pass that motivated this PR's first attempt — which added bailout detection but left the broken idiom in place, so it did not fix the thing it claimed to.

## The fix

Mirror what CI already does correctly (`.github/workflows/ci.yml`, "Run clang-tidy on changed lines"):

- Inject `--warnings-as-errors='*'` through a binary shim — `clang-tidy-diff.py` forwards only a fixed flag set and rejects the flag directly, which is why CI uses a shim too.
- **Gate on the driver's exit code.** It returns non-zero when any child fails, covering findings, compile errors, crashes and timeouts alike — no message-text matching anywhere in the pass/fail decision.
- Drop `-quiet`, matching CI and restoring the `Found compiler error(s)` banner. (It also made half the previous attempt's detection dead code, since `-quiet` suppresses that exact string.)

The compile-bailout grep survives **only as an explanatory hint**, emitted after the exit code has already decided the outcome. It greps the file rather than a pipe, so it cannot hit the SIGPIPE trap, and is anchored at column 0 so an echoed source line containing the phrase cannot masquerade as a real bailout.

## Verification

| Scenario | Result |
|---|---|
| Clean DB + real violation (`modernize-use-nullptr`) | exit 1 |
| Clean DB + benign change | exit 0, `OK` |
| Deliberately contaminated compile DB (329 GCC-only flags) | exit 1 + bailout hint |
| 477 KB output, 397 files, real problems | exit 1 (old logic: missed both checks) |

## Known remaining gaps (pre-existing, not addressed here)

- A changed `.cpp` absent from `compile_commands.json` is analyzed as zero diagnostics and still reports OK — likelier in practice than a compile bailout (add a file, forget to reconfigure, push). Worth a follow-up cross-check against the DB's file list.
- Local uses `-path build/Release` while CI uses `build/RelWithDebInfo`, and CI passes `-config-file .clang-tidy` while the local script relies on directory-hierarchy discovery (which is what honours `tests/.clang-tidy`). Both are real parity divergences, deliberately left alone to keep this change focused.

## Notes

No CHANGELOG entry — developer tooling only, matching `607149c` which added this gate.

The first commit on this branch is kept rather than amended, so the review trail showing the original approach was wrong stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)