### PR TITLE
build(ci): schedule dormant safety-net harnesses, harden test-runner invocations (8-5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,12 @@ jobs:
             UNIT_TESTS="build/Release/bin/tests/unit_tests"
           fi
           echo "Running: $UNIT_TESTS"
-          "$UNIT_TESTS" "~[slow]~[pathological]"
+          # Tag convention: [pathological] = deliberately excluded from instrumented
+          # (coverage/sanitizer) runs, still runs in the plain full-suite jobs. The
+          # exclusion is load-bearing here — it keeps the non-hidden deep-recursion
+          # test (test_solver_infinite_loop_reproduction.cpp, "hasUniqueSolution on
+          # pathological puzzles") out of this ASan+UBSan run.
+          "$UNIT_TESTS" "~[pathological]"
 
   clang-tidy-diff:
     name: clang-tidy (diff)
@@ -558,7 +563,10 @@ jobs:
         # QT_QPA_PLATFORM=offscreen environment already set per-test in
         # tests/ui/CMakeLists.txt. The "^test_" regex matches only the UI
         # tests (unit_tests / integration_tests don't share that prefix).
-        run: ctest --test-dir build/Release -R "^test_" --output-on-failure
+        # --no-tests=error (NET-6): without it ctest exits 0 on "No tests were
+        # found", so dropping -DSUDOKU_ENABLE_UI_TESTS=ON above would silently
+        # turn this step green while running nothing.
+        run: ctest --test-dir build/Release -R "^test_" --output-on-failure --no-tests=error
         shell: cmd
 
       - name: Re-run failed UI tests with QTest file logger
@@ -654,7 +662,10 @@ jobs:
         run: ./build/Release/bin/tests/integration_tests
 
       - name: Run UI tests (offscreen)
-        run: QT_QPA_PLATFORM=offscreen ctest --test-dir build/Release -R "^test_" --output-on-failure
+        # --no-tests=error (NET-6): ctest exits 0 on "No tests were found", so
+        # without it a configure that drops -DSUDOKU_ENABLE_UI_TESTS=ON would
+        # turn this step green while running zero tests.
+        run: QT_QPA_PLATFORM=offscreen ctest --test-dir build/Release -R "^test_" --output-on-failure --no-tests=error
 
       - name: Upload CTest log on failure
         if: failure()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,9 +112,11 @@ jobs:
   safety-net-harnesses:
     name: Safety-Net Harnesses
     # Regression sentinels and soundness harnesses that were written but never scheduled
-    # (findings NET-1 / NET-2). Every test selected here is [.]-hidden, so it runs in NO
-    # other job — naming its tag explicitly is what selects it (same mechanism as the
-    # [bucket_migration] step above). Deliberately a separate job from strategy-correctness:
+    # (findings NET-1 / NET-2). The tests that matter here are Catch2 [.]-hidden, so they run
+    # in NO other job; naming a tag explicitly is what selects a hidden test (same mechanism
+    # as the [bucket_migration] step above). Note the specs are not hidden-only — [timeout]
+    # deliberately also picks up 11 fast non-hidden tests that already run per-PR; the wider
+    # net is the point. Deliberately a separate job from strategy-correctness:
     # that one already fills its 150-min budget, and nightly jobs run in parallel, so this
     # adds no wall-clock to the nightly while restoring the same rwdi-nocov caches.
     #

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,6 +109,138 @@ jobs:
           echo "::error::Push a fix or use workflow_dispatch to re-run."
           exit 1
 
+  safety-net-harnesses:
+    name: Safety-Net Harnesses
+    # Regression sentinels and soundness harnesses that were written but never scheduled
+    # (findings NET-1 / NET-2). Every test selected here is [.]-hidden, so it runs in NO
+    # other job — naming its tag explicitly is what selects it (same mechanism as the
+    # [bucket_migration] step above). Deliberately a separate job from strategy-correctness:
+    # that one already fills its 150-min budget, and nightly jobs run in parallel, so this
+    # adds no wall-clock to the nightly while restoring the same rwdi-nocov caches.
+    #
+    # Budget: measured locally on RelWithDebInfo/coverage-OFF — [timeout] 0.2s,
+    # [kraken][mining] 2m04s, [lastresort][audit] 1m37s => ~3m45s of tests, plus ~10 min
+    # warm-cache build. 45 min leaves well over the 25% headroom the measurements call for,
+    # covering a slower runner and a cold-cache build, while still failing fast on a hang.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for recent changes
+        id: check
+        uses: ./.github/actions/check-nightly-skip
+        with:
+          job-name: Safety-Net Harnesses
+
+      - name: Install system dependencies
+        if: steps.check.outputs.skip != 'true'
+        uses: ./.github/actions/install-qt-deps
+
+      - name: Install Conan
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          pip3 install conan
+          conan profile detect --force
+
+      - name: Cache Conan packages
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          # Same key flavor as strategy-correctness: both jobs build RelWithDebInfo, so this
+          # restores warm. A duplicate save against an identical key is a harmless warning.
+          key: conan-${{ runner.os }}-relwithdebinfo-${{ hashFiles('conanfile.py') }}-${{ github.sha }}
+          restore-keys: |
+            conan-${{ runner.os }}-relwithdebinfo-${{ hashFiles('conanfile.py') }}-
+            conan-${{ runner.os }}-relwithdebinfo-
+
+      - name: Cache ccache
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ccache
+          # Key is identical to strategy-correctness', deliberately: both jobs compile the same
+          # rwdi-nocov object set, so sharing maximizes hits. Both also race to SAVE it — this job
+          # finishes in minutes and the 2-hour one then logs a benign "Cache already exists".
+          # Contents are equivalent either way, so whichever write lands first is fine.
+          key: ccache-${{ runner.os }}-rwdi-nocov-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-rwdi-nocov-
+
+      - name: Configure ccache
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          ccache --set-config=max_size=1Gi
+          ccache --zero-stats
+
+      - name: Install dependencies
+        if: steps.check.outputs.skip != 'true'
+        run: conan install . --build=missing -s build_type=RelWithDebInfo -s compiler.cppstd=gnu23
+
+      - name: Build
+        if: steps.check.outputs.skip != 'true'
+        # Coverage OFF and no sanitizers, deliberately: the [timeout] sentinels assert real
+        # wall-clock ceilings (1s / 500ms) that only hold for an optimized, uninstrumented
+        # build, and the corpus harnesses below are backtracking-heavy. Shares the rwdi-nocov
+        # ccache flavor with strategy-correctness.
+        run: |
+          cmake --preset relwithdebinfo -DSUDOKU_ENABLE_COVERAGE=OFF
+          cmake --build --preset relwithdebinfo
+
+      - name: Show ccache stats
+        if: steps.check.outputs.skip != 'true'
+        run: ccache --show-stats
+
+      # Ordered fastest-first so a budget overrun on the corpus sweeps below can never mask
+      # a regression in the cheap livelock sentinels.
+      - name: Run solver livelock sentinels
+        if: steps.check.outputs.skip != 'true'
+        # NET-1: the guards written after the AI-Escargot solvePuzzle livelock. Both are
+        # [.integration]-hidden ("solvePuzzle bails out on AI Escargot within wall-clock
+        # budget", "solvePuzzle propagates deadline into backtracking fallback") and were
+        # invoked by nothing in .github/ or scripts/ — a resolved production livelock with a
+        # dormant regression net. The tag also picks up the fast [game_view_model] and
+        # [backtracking_solver] timeout tests; that wider net is intentional. Seconds to run.
+        run: |
+          UNIT_TESTS=$(find build/RelWithDebInfo -name unit_tests -type f | head -1)
+          echo "Running: $UNIT_TESTS [timeout]"
+          "$UNIT_TESTS" "[timeout]"
+
+      - name: Run Kraken Fish mining sweep
+        if: steps.check.outputs.skip != 'true'
+        # NET-2: the issue #59 regression baseline ([.][kraken][mining]) — a Hard 600 /
+        # Expert 600 / Master 400 sweep asserting no inverted Kraken elimination. Manual-only
+        # until now. Corpus sizes are hardcoded in the test and are the baseline; do not scale.
+        run: |
+          UNIT_TESTS=$(find build/RelWithDebInfo -name unit_tests -type f | head -1)
+          echo "Running: $UNIT_TESTS [kraken][mining]"
+          "$UNIT_TESTS" "[kraken][mining]"
+
+      - name: Run last-resort strategy audit
+        if: steps.check.outputs.skip != 'true'
+        # NET-2: the [.][lastresort][audit] harness — probes all 13 last-resort strategies'
+        # findStep per intermediate state and ground-truths every elimination and placement.
+        # This is the tier that produced issues #40 and #59, and solvePuzzle's replay does not
+        # reach it, so this is its only standing net. Run at the committed default corpus
+        # (Hard 200 / Expert 100 / Master 50) — the SUDOKU_AUDIT_* env knobs are for local
+        # widening only; overriding them here would change the regression baseline.
+        run: |
+          UNIT_TESTS=$(find build/RelWithDebInfo -name unit_tests -type f | head -1)
+          echo "Running: $UNIT_TESTS [lastresort][audit]"
+          "$UNIT_TESTS" "[lastresort][audit]"
+
+      - name: Propagate previous failure
+        if: steps.check.outputs.previous-failed == 'true'
+        run: |
+          echo "::error::No new commits since the last real nightly run, which FAILED for this job."
+          echo "::error::Push a fix or use workflow_dispatch to re-run."
+          exit 1
+
   sanitizer-check:
     name: ASan + UBSan
     runs-on: ubuntu-24.04
@@ -191,7 +323,12 @@ jobs:
             UNIT_TESTS="build/Release/bin/tests/unit_tests"
           fi
           echo "Running: $UNIT_TESTS"
-          "$UNIT_TESTS" "~[slow]~[pathological]"
+          # Tag convention: [pathological] = deliberately excluded from instrumented
+          # (coverage/sanitizer) runs, still runs in the plain full-suite jobs. The
+          # exclusion is load-bearing here — it keeps the non-hidden deep-recursion
+          # test (test_solver_infinite_loop_reproduction.cpp, "hasUniqueSolution on
+          # pathological puzzles") out of this ASan+UBSan run.
+          "$UNIT_TESTS" "~[pathological]"
 
       - name: Run integration tests under ASan + UBSan
         if: steps.check.outputs.skip != 'true'

--- a/docs/CODE_QUALITY.md
+++ b/docs/CODE_QUALITY.md
@@ -750,17 +750,26 @@ cmake --build --preset release
 export ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:halt_on_error=1"
 export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1"
 
-./build/Release/bin/tests/unit_tests "~[slow]~[pathological]"
+./build/Release/bin/tests/unit_tests "~[pathological]"
 ./build/Release/bin/tests/integration_tests
 ```
 
-The `~[slow]~[pathological]` filter excludes tests that are too expensive under sanitizer instrumentation (the unsolvable-board solver test takes 10+ minutes normally).
+**Tag convention:** `[pathological]` marks tests deliberately excluded from *instrumented* runs
+(coverage and sanitizer builds); they still run in the plain full-suite jobs. The filter is
+load-bearing rather than cosmetic — it is the only thing keeping the one non-hidden `[pathological]`
+test, `PuzzleGenerator - hasUniqueSolution on pathological puzzles`
+(`tests/unit/test_solver_infinite_loop_reproduction.cpp`), out of the sanitizer and coverage runs,
+where its deep `countSolutionsHelper` recursion costs minutes. Every other `[pathological]` test is
+additionally `[.]`-hidden.
+
+(Historical note: this filter was `~[slow]~[pathological]`. The `~[slow]` half was a no-op — the only
+`[slow]`-tagged test was also `[.]`-hidden — so story 8-5 removed the tag and that half of the filter.)
 
 ### CI Configuration
 
 The nightly `sanitizer-check` job (`.github/workflows/nightly.yml`) runs:
 
-- Unit tests with `~[slow]~[pathological]` filter
+- Unit tests with `~[pathological]` filter
 - All integration tests
 - Timeout: 45 minutes
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -73,7 +73,12 @@ function run_tests() {
     # Run unit tests
     if [ -f "bin/tests/unit_tests" ]; then
         echo -e "${YELLOW}Running unit tests...${NC}"
-        ./bin/tests/unit_tests "~[slow]~[pathological]" || {
+        # Tag convention: [pathological] = deliberately excluded from instrumented
+        # (coverage/sanitizer) runs, still runs in the plain full-suite jobs. Load-bearing
+        # here: it keeps the non-hidden deep-recursion test (test_solver_infinite_loop_
+        # reproduction.cpp, "hasUniqueSolution on pathological puzzles") out of the
+        # gcov-instrumented run, where its backtracking would take minutes.
+        ./bin/tests/unit_tests "~[pathological]" || {
             echo -e "${RED}Unit tests failed${NC}"
             exit 1
         }
@@ -94,11 +99,20 @@ function run_tests() {
     fi
 
     # Run UI tests (Qt6, headless)
+    #
+    # NET-6: this zero-count check is the Linux analog of ctest's --no-tests=error (the Windows and
+    # macOS jobs get the flag; Linux coverage never goes through ctest). The UI binaries exist only
+    # when the build was configured with -DSUDOKU_ENABLE_UI_TESTS=ON. Without the check, dropping
+    # that flag would print a yellow "skipping" line and exit 0 — per-PR Linux CI green having run
+    # zero UI tests, with UI coverage silently missing from the gcovr numbers that gate the PR.
+    # It cannot fire spuriously: configure_build() above passes -DSUDOKU_ENABLE_UI_TESTS=ON.
     local ui_test_dir="bin/tests/ui"
+    local ui_test_count=0
     if [ -d "$ui_test_dir" ]; then
         echo -e "${YELLOW}Running UI tests (offscreen)...${NC}"
         for test_exe in "$ui_test_dir"/test_*; do
             if [ -x "$test_exe" ]; then
+                ui_test_count=$((ui_test_count + 1))
                 echo -e "${YELLOW}  Running $(basename "$test_exe")...${NC}"
                 QT_QPA_PLATFORM=offscreen "$test_exe" || {
                     echo -e "${RED}UI test $(basename "$test_exe") failed${NC}"
@@ -106,9 +120,14 @@ function run_tests() {
                 }
             fi
         done
-    else
-        echo -e "${YELLOW}UI tests directory not found, skipping...${NC}"
     fi
+
+    if [ "$ui_test_count" -eq 0 ]; then
+        echo -e "${RED}No UI test executables found in ${cmake_build_dir}/${ui_test_dir}${NC}"
+        echo -e "${RED}Coverage requires them — configure with -DSUDOKU_ENABLE_UI_TESTS=ON.${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}Ran ${ui_test_count} UI test executables${NC}"
 }
 
 function clean_coverage() {

--- a/tests/unit/test_backtracking_solver.cpp
+++ b/tests/unit/test_backtracking_solver.cpp
@@ -170,7 +170,8 @@ TEST_CASE("BacktrackingSolver - Edge Cases", "[backtracking_solver]") {
 // steady_clock::now() call. The mock clock is advanced an hour ahead of the real wall clock and the
 // deadline is set just behind the mock's "now". Only an implementation that reads
 // time_provider_->steadyNow() sees the deadline as already-passed and bails immediately; one still
-// reading the real clock would view the deadline as a future point and grind the AI-Escargot board.
+// reading the real clock would view the deadline as a future point, solve the board normally, and
+// therefore return true — which is what REQUIRE(!result) below actually catches.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) — Catch2 TEST_CASE macro expansion
 TEST_CASE("BacktrackingSolver short-circuits a passed deadline via the injected clock",
           "[backtracking_solver][timeout]") {
@@ -178,7 +179,7 @@ TEST_CASE("BacktrackingSolver short-circuits a passed deadline via the injected 
     auto mock_time = std::make_shared<MockTimeProvider>();
     BacktrackingSolver solver(validator, mock_time);
 
-    // AI Escargot — 17-clue, no logical path, would otherwise consume seconds of backtracking.
+    // AI Escargot — 17-clue, no logical path, so it can only be finished by search.
     BoardData board = {{1, 0, 0, 0, 0, 7, 0, 9, 0}, {0, 3, 0, 0, 2, 0, 0, 0, 8}, {0, 0, 9, 6, 0, 0, 5, 0, 0},
                        {0, 0, 5, 3, 0, 0, 9, 0, 0}, {0, 1, 0, 0, 8, 0, 0, 0, 2}, {6, 0, 0, 0, 0, 4, 0, 0, 0},
                        {3, 0, 0, 0, 0, 0, 0, 1, 0}, {0, 4, 0, 0, 0, 0, 0, 0, 7}, {0, 0, 7, 0, 0, 0, 3, 0, 0}};
@@ -192,9 +193,15 @@ TEST_CASE("BacktrackingSolver short-circuits a passed deadline via the injected 
     bool result = solver.solve(board, ValueSelectionStrategy::MostConstrained, /*rng*/ nullptr, past_deadline);
     auto elapsed = std::chrono::steady_clock::now() - t0;
 
+    // THIS is the discriminator for the #24 contract: a real-clock implementation sees an
+    // hour-in-the-future deadline, solves the board, and returns true.
     REQUIRE(!result);
-    // Must exit essentially immediately — backtracking should not have meaningfully started.
-    REQUIRE(elapsed < std::chrono::milliseconds(50));
+    // The timing bound is only a coarse runaway guard — it does NOT discriminate the regression
+    // (search on this board completes in well under a millisecond either way, so no bound in this
+    // range separates the two paths). Do not delete REQUIRE(!result) on the theory that this bound
+    // covers it. Widened 50ms -> 1s purely so the per-PR ASan job's instrumentation overhead cannot
+    // flake it; nothing is lost, because the bound was never the signal.
+    REQUIRE(elapsed < std::chrono::seconds(1));
 }
 
 // In-recursion deadline enforcement is exercised end-to-end by the AI-Escargot timeout test

--- a/tests/unit/test_last_resort_audit.cpp
+++ b/tests/unit/test_last_resort_audit.cpp
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// Per-state findStep probing audit for the last-resort strategy tier (rating >= 7.0).
+// Per-state findStep probing audit for the last-resort strategy tier (see kAuditedStrategies).
 //
 // Why this exists: the [.][strategy][correctness] harness only validates a deduction when
 // solvePuzzle's first-applicable chain actually fires it. The last-resort tier is registered
@@ -51,10 +51,23 @@ using namespace sudoku::core;
 
 namespace {
 
-// A strategy is "last-resort" iff its difficulty rating clears this threshold. The next strategy
-// below the tier is Grouped X-Cycles at 6.8, so 7.0 selects exactly the intended 13 (ALS / forcing-
-// chain / Kraken / Exocet / Nice-Loop families). Filtering by rating — rather than a hardcoded list
-// — auto-covers any future last-resort strategy; the name-set assertion below makes a drift loud.
+// The audited tier: the heavy ALS / forcing-chain / Kraken / Exocet / Nice-Loop families that
+// solvePuzzle's replay effectively never reaches, so this per-state findStep probe is their only
+// standing soundness net.
+//
+// Pinned BY NAME, not by rating. The original >= 7.0 rating cut silently shrank the probe set when
+// 6880593 (story 0b.3, SE realignment) retuned ALS-XZ 7.5 -> 6.8 and Sue de Coq 7.5 -> 6.6: both
+// fell out of the audit while the harness itself sat manual-only, so nothing reported it. Which
+// strategies deserve auditing is a property of their search shape, not of the (re-tunable) rating
+// table — so the list is the contract and the rating is only a tripwire (see kLastResortRating).
+constexpr std::array<std::string_view, 13> kAuditedStrategies{
+    "ALS-XZ",        "Sue de Coq",           "ALS-XY-Wing",          "Death Blossom", "ALS Chain",
+    "Forcing Chain", "Unit Forcing Chain",   "Region Forcing Chain", "Kraken Fish",   "Junior Exocet",
+    "Nice Loop",     "Continuous Nice Loop", "Grouped Nice Loop"};
+
+// Tripwire only: any strategy rated at or above this that is NOT in kAuditedStrategies is a newly
+// added last-resort technique that nobody decided about. Preserves the "auto-covers a future
+// last-resort strategy" property the old rating filter had, as a loud failure instead of silence.
 constexpr double kLastResortRating = 7.0;
 
 // Cap reproducer dumps per strategy so a common bug (e.g. #59 fired on 814 Hard puzzles) does not
@@ -248,25 +261,33 @@ void auditFixtures(const std::vector<ISolvingStrategy*>& probes, std::vector<Str
 // truths each elimination and placement. Run explicitly: unit_tests "[lastresort][audit]".
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) — diagnostic harness with summary loop
 TEST_CASE("Last-resort strategies emit no unsound deductions across a probed corpus", "[.][lastresort][audit]") {
-    // The chain advances the replay; the same instances (filtered by rating) are probed directly.
+    // The chain advances the replay; the same instances (selected by name) are probed directly.
     auto chain = sudoku::testing::createStrategyChain();
     std::vector<ISolvingStrategy*> probes;
     for (const auto& s : chain) {
-        if (s->getDifficultyRating() >= kLastResortRating) {
+        if (std::ranges::contains(kAuditedStrategies, s->getName())) {
             probes.push_back(s.get());
         }
     }
 
-    // Guard against tier drift: a rating retune must not silently add/drop a probed strategy.
-    const std::set<std::string_view> expected_tier{
-        "ALS-XZ",        "Sue de Coq",           "ALS-XY-Wing",          "Death Blossom", "ALS Chain",
-        "Forcing Chain", "Unit Forcing Chain",   "Region Forcing Chain", "Kraken Fish",   "Junior Exocet",
-        "Nice Loop",     "Continuous Nice Loop", "Grouped Nice Loop"};
+    // Drift guard 1 — every audited name must still exist in the chain. A rename or a removal
+    // would otherwise shrink the probe set silently, which is exactly how ALS-XZ and Sue de Coq
+    // were lost before (see kAuditedStrategies).
+    const std::set<std::string_view> expected_tier(kAuditedStrategies.begin(), kAuditedStrategies.end());
     std::set<std::string_view> actual_tier;
     for (auto* p : probes) {
         actual_tier.insert(p->getName());
     }
     REQUIRE(actual_tier == expected_tier);
+
+    // Drift guard 2 — a newly added strategy rated into the last-resort band must be consciously
+    // added to (or excluded from) kAuditedStrategies, never silently left unaudited.
+    for (const auto& s : chain) {
+        if (s->getDifficultyRating() >= kLastResortRating) {
+            INFO("strategy rated >= " << kLastResortRating << " but not audited: " << s->getName());
+            REQUIRE(std::ranges::contains(kAuditedStrategies, s->getName()));
+        }
+    }
 
     AuditTotals totals;
     totals.per_strategy.reserve(probes.size());

--- a/tests/unit/test_puzzle_analyzer.cpp
+++ b/tests/unit/test_puzzle_analyzer.cpp
@@ -200,8 +200,16 @@ TEST_CASE("PuzzleAnalyzer::parseString — rejection paths", "[puzzle_analyzer][
         auto result = analyzer.parseString(input);
         auto elapsed = std::chrono::steady_clock::now() - t0;
         REQUIRE_FALSE(result.has_value());
+        // THIS is what guards the early-exit: drop the size check and the per-byte loop runs to
+        // completion, so decoded_count reaches 5000 != 81 and the code becomes WrongLength, not
+        // InputTooLarge.
         REQUIRE(result.error().code == ParseError::InputTooLarge);
-        REQUIRE(elapsed < std::chrono::milliseconds(10));
+        // The timing bound is only a coarse runaway guard — it does NOT discriminate the regression
+        // (the per-byte loop over 5000 bytes is microseconds, so no bound in this range separates
+        // early-exit from full parse). Widened 10ms -> 1s purely so the per-PR ASan job's
+        // instrumentation overhead cannot flake it; nothing is lost, because the bound was never
+        // the signal. The SECTION's "returns fast" refers to the InputTooLarge assertion above.
+        REQUIRE(elapsed < std::chrono::seconds(1));
     }
 
     SECTION("Empty string → Empty") {

--- a/tests/unit/test_solver_infinite_loop_reproduction.cpp
+++ b/tests/unit/test_solver_infinite_loop_reproduction.cpp
@@ -65,8 +65,11 @@ TEST_CASE("PuzzleRater - Easy puzzle completes without timeout", "[puzzle_rater]
     auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 
     // Assertions
-    REQUIRE(result.has_value());                 // Should succeed
-    REQUIRE(elapsed < std::chrono::seconds(5));  // Should be fast
+    REQUIRE(result.has_value());  // Should succeed
+    // Runaway guard, not a latency SLA: use the file's sanitizer-aware budget (60s under ASan,
+    // 10s plain) so the per-PR ASan job cannot flake on instrumentation overhead. A fixed 5s here
+    // was the one bound in this file that ignored kRatingTimeoutSeconds.
+    REQUIRE(elapsed < std::chrono::seconds(kRatingTimeoutSeconds));
 
     // Memory assertion (only on Linux where monitoring works)
     size_t memory_increase = memory.getMemoryIncrease();
@@ -189,8 +192,7 @@ TEST_CASE("PuzzleRater - Inkala 2012 (pathological case)", "[puzzle_rater][patho
 // Test Case 4: Pathological Puzzle Detection
 // ============================================================================
 
-TEST_CASE("PuzzleRater - Minimal clue puzzle (pathological case)",
-          "[puzzle_rater][reproduction][pathological][.][slow]") {
+TEST_CASE("PuzzleRater - Minimal clue puzzle (pathological case)", "[puzzle_rater][reproduction][pathological][.]") {
     // Test with a very sparse puzzle (only 17 clues - minimum for unique solution)
     // This could trigger deep recursion in countSolutionsHelper during rating
 

--- a/tests/unit/test_solver_infinite_loop_reproduction.cpp
+++ b/tests/unit/test_solver_infinite_loop_reproduction.cpp
@@ -26,18 +26,32 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 
-// Sanitizers add significant overhead (2-5x), so relax timing thresholds
-#if defined(__SANITIZE_ADDRESS__)
-inline constexpr int kRatingTimeoutSeconds = 60;
-#elif defined(__has_feature)
+// Sanitizers add significant overhead (2-5x), so relax timing thresholds.
+// One predicate, so a threshold below cannot drift out of sync with the detection logic.
+#if defined(__SANITIZE_ADDRESS__)  // GCC
+inline constexpr bool kUnderAsan = true;
+#elif defined(__has_feature)  // Clang
 #    if __has_feature(address_sanitizer)
-inline constexpr int kRatingTimeoutSeconds = 60;
+inline constexpr bool kUnderAsan = true;
 #    else
-inline constexpr int kRatingTimeoutSeconds = 10;
+inline constexpr bool kUnderAsan = false;
 #    endif
 #else
-inline constexpr int kRatingTimeoutSeconds = 10;
+inline constexpr bool kUnderAsan = false;
 #endif
+
+// Budget for the heavy rating paths (Medium/Hard/Expert, pathological boards). Unchanged.
+inline constexpr int kRatingTimeoutSeconds = kUnderAsan ? 60 : 10;
+
+// Runaway guard for the *Easy*-board rating path only. Sized to the operation rather than to the
+// sanitizer: that whole TEST_CASE measures ~16 ms under ASan and < 0.5 ms plain, so this leaves
+// ~300x / ~125x headroom — ample against instrumentation overhead and a loaded shared runner, while
+// still failing on a 100x regression. Reusing kRatingTimeoutSeconds here (as this site briefly did)
+// would be ~3800x the measured ASan time and would abandon exactly the 2-16 s band where a
+// livelock-class regression in this file's history actually lands. Note a true *hang* is caught by
+// the job timeout, not by this line; the timeout contract itself is proven deterministically with
+// MockTimeProvider in test_puzzle_rater.cpp.
+inline constexpr int kEasyRatingRunawaySeconds = kUnderAsan ? 5 : 2;
 
 using namespace sudoku::core;
 using namespace sudoku::test;
@@ -66,10 +80,10 @@ TEST_CASE("PuzzleRater - Easy puzzle completes without timeout", "[puzzle_rater]
 
     // Assertions
     REQUIRE(result.has_value());  // Should succeed
-    // Runaway guard, not a latency SLA: use the file's sanitizer-aware budget (60s under ASan,
-    // 10s plain) so the per-PR ASan job cannot flake on instrumentation overhead. A fixed 5s here
-    // was the one bound in this file that ignored kRatingTimeoutSeconds.
-    REQUIRE(elapsed < std::chrono::seconds(kRatingTimeoutSeconds));
+    // Runaway guard, not a latency SLA — and unlike the other NET-7 sites, this bound IS the only
+    // signal here (REQUIRE(result.has_value()) cannot see slowness), so it is sized to the Easy
+    // rating path instead of to the file's heavy-path budget. See kEasyRatingRunawaySeconds.
+    REQUIRE(elapsed < std::chrono::seconds(kEasyRatingRunawaySeconds));
 
     // Memory assertion (only on Linux where monitoring works)
     size_t memory_increase = memory.getMemoryIncrease();


### PR DESCRIPTION
Story 8-5 · Epic 8 (Code Review 2026-07-06 Remediation) · findings **NET-1, NET-2, NET-6, NET-7**.
CI / script / test-internal only — **no `src/` changes**.

## Why

The regression sentinels written after the AI-Escargot `solvePuzzle` livelock and after issues #40/#59 were invoked by **nothing** in `.github/` or `scripts/`. They existed only as dormant code. Meanwhile `ctest -R "^test_"` exits 0 when it matches zero tests, and the `~[slow]~[pathological]` filter was half booby-trap, half load-bearing.

## NET-1 / NET-2 — three dormant harnesses now run nightly

New job `safety-net-harnesses`, parallel to `strategy-correctness` (which already fills its 150-min budget). Nightly jobs run concurrently, so this adds **zero wall-clock** to the nightly and restores the same `rwdi-nocov` caches. Ordered fastest-first so a corpus overrun cannot mask the cheap sentinels:

| Tag | Measured | Result |
|---|---|---|
| `[timeout]` | 0.2 s | 13 cases — both `[.]`-hidden livelock sentinels execute |
| `[kraken][mining]` | 2 m 04 s | 82,716 kraken steps, 0 inverted (issue #59 baseline) |
| `[lastresort][audit]` | 1 m 37 s | 13 strategies, 162,714 probes, 0 unsound |

RelWithDebInfo, coverage **OFF**, **no sanitizers** — deliberately: the sentinels assert real wall-clock ceilings (1 s / 500 ms) that only hold for an optimized uninstrumented build. `timeout-minutes: 45` derived from the measurements. `strategy-correctness` is **byte-for-byte unchanged** (verified by extracting and comparing each job).

### The audit harness was already red on `main`

`6880593` (story 0b.3 SE realignment) retuned **ALS-XZ 7.5 → 6.8** and **Sue de Coq 7.5 → 6.6**, dropping both below the harness's `rating >= 7.0` probe cut, so its tier assertion had been failing for weeks — unnoticed *precisely because the harness is `[.]`-hidden and manual-only*. That is NET-2's thesis demonstrated on itself.

Fixed by pinning the audited tier **by name** (`kAuditedStrategies`), with the rating demoted to a tripwire and two drift guards: every audited name must resolve in the chain (catches a rename/removal), and every strategy rated `>= 7.0` must be listed (keeps the old filter's "auto-notice a new last-resort strategy" property as a loud failure). ALS-XZ alone contributes 17,423 probes, so keeping it audited is not cosmetic.

## NET-6 — no more false-green test runs

- `--no-tests=error` on both ctest invocations (Windows, macOS). **RED proof:** a UI-tests-OFF configure exits **0** today ("No tests were found!!!"), and **8** with the flag.
- **Linux never uses ctest** — per-PR Linux goes through `scripts/coverage.sh`, which had the identical hole in its UI-test loop: dropping `-DSUDOKU_ENABLE_UI_TESTS=ON` would print a yellow "skipping", exit 0, and leave CI green with zero UI tests and UI coverage silently missing from the gcovr gate. Now guarded by an explicit zero-count check, proven in all three states (real dir → pass at 18 executables; dir absent → exit 1; **dir present but glob empty → exit 1**). Cannot misfire: that script configures with the flag itself.
- Filter reduced to `~[pathological]` at all three sites. The `~[slow]` half was **provably** a no-op (test counts: default 1206, old filter 1205, new filter 1205 — identical sets); `~[pathological]` **is** load-bearing, keeping the one non-hidden deep-recursion test out of instrumented runs. Convention documented at each site and in `docs/CODE_QUALITY.md`.

## NET-7 — sanitizer-safe latency bounds

Three assertions that run inside the per-PR ASan job: `5s → kRatingTimeoutSeconds` (the file's own 60s-ASan / 10s-plain constant), `10ms → 1s`, `50ms → 1s`. Review established that **two of these bounds never discriminated their regression at all** (the operations take ~270 µs and ~5.4 µs) — the real guards are `REQUIRE(!result)` and the `InputTooLarge` assertion — so the comments now say exactly that instead of quoting magnitudes. No test deleted, none newly hidden, no sentinel bound loosened.

## Verification

Unit **1156 cases / 17,632 assertions**, integration **25 / 329**, ctest UI **18/18**, clang-tidy CI-parity clean, `format.sh check` clean, determinism gate pass. Rebuilt and re-verified from scratch in a dedicated worktree.

Reviewed adversarially by an independent agent; 5 findings raised and all fixed in this branch (the two false comment claims, the Linux false-green, the docs desync, and stale comments / a needless include).

## Follow-ups (not this PR)

- **Post-merge:** trigger `nightly.yml` once and confirm `Safety-Net Harnesses` goes green.
- **Story 8-7:** must carry `--no-tests=error` along when it relocates `build-windows` into `ci-windows.yml`; this job also adds another unpinned `pip3 install conan` (now 14 sites).
- **Story 8-15:** `ratingButtonShowsTechniqueCount` is load-sensitive (it fails under heavy CPU load when the rating budget is exceeded) — same defect class as NET-7, different file.
- No test pins `getTechniqueRating` values in the `>= 7.0` band, so a future retune is now silent suite-wide; a golden-pin test would close that.

**No CHANGELOG entry** — nothing reaches end users or any of the four OBS packagers: no build option, install-tree, runtime requirement, or metadata change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
