### PR TITLE
refactor: split two functions past clang-tidy's function-size threshold

### DIFF
--- a/src/core/statistics_manager.cpp
+++ b/src/core/statistics_manager.cpp
@@ -655,22 +655,7 @@ void StatisticsManager::updateAggregateStats(const GameStats& completed_game) co
 
     // Update rating statistics BEFORE incrementing games_played (track for all games, not just completed)
     if (counts_as_new_attempt && completed_game.puzzle_rating > 0.0) {
-        // Get count BEFORE incrementing
-        auto games_count_before = cached_stats_.games_played[diff_index];
-
-        // Update min rating
-        cached_stats_.min_ratings[diff_index] =
-            std::min(cached_stats_.min_ratings[diff_index], completed_game.puzzle_rating);
-
-        // Update max rating
-        cached_stats_.max_ratings[diff_index] =
-            std::max(cached_stats_.max_ratings[diff_index], completed_game.puzzle_rating);
-
-        // Update average rating
-        auto current_rating_average = cached_stats_.average_ratings[diff_index];
-        cached_stats_.average_ratings[diff_index] =
-            (current_rating_average * static_cast<double>(games_count_before) + completed_game.puzzle_rating) /
-            static_cast<double>(games_count_before + 1);
+        updateRatingStats(diff_index, completed_game);
     }
 
     // Update per-difficulty stats
@@ -707,11 +692,37 @@ void StatisticsManager::updateAggregateStats(const GameStats& completed_game) co
         cached_stats_.current_win_streak = 0;
     }
 
-    // Bank this segment's own play only. The record deliberately reports the puzzle's running
-    // totals (story 8.1 AC8, which is what keeps best_times truthful for a resumed win), so adding
-    // it whole re-banks everything the previous segment already banked — an inflation that compounds
-    // with every quit→resume cycle and, because it is written into the session log, survives a
-    // rebuild. best_times / average_times above deliberately keep using the full time_played.
+    // Bank this segment's own play only — see updateCarriedTotals for why only the delta counts.
+    updateCarriedTotals(completed_game);
+
+    stats_cache_valid_ = true;
+}
+
+void StatisticsManager::updateRatingStats(int diff_index, const GameStats& completed_game) const {
+    // Get count BEFORE incrementing
+    auto games_count_before = cached_stats_.games_played[diff_index];
+
+    // Update min rating
+    cached_stats_.min_ratings[diff_index] =
+        std::min(cached_stats_.min_ratings[diff_index], completed_game.puzzle_rating);
+
+    // Update max rating
+    cached_stats_.max_ratings[diff_index] =
+        std::max(cached_stats_.max_ratings[diff_index], completed_game.puzzle_rating);
+
+    // Update average rating
+    auto current_rating_average = cached_stats_.average_ratings[diff_index];
+    cached_stats_.average_ratings[diff_index] =
+        (current_rating_average * static_cast<double>(games_count_before) + completed_game.puzzle_rating) /
+        static_cast<double>(games_count_before + 1);
+}
+
+void StatisticsManager::updateCarriedTotals(const GameStats& completed_game) const {
+    // The record deliberately reports the puzzle's running totals (story 8.1 AC8, which is what
+    // keeps best_times truthful for a resumed win), so adding it whole re-banks everything the
+    // previous segment already banked — an inflation that compounds with every quit→resume cycle
+    // and, because it is written into the session log, survives a rebuild. best_times /
+    // average_times in updateAggregateStats deliberately keep using the full time_played.
     //
     // continued_from_save is the single source of truth for "this record continues an earlier
     // segment"; carried_* is only its magnitude. A record that does not claim to be a continuation
@@ -732,8 +743,6 @@ void StatisticsManager::updateAggregateStats(const GameStats& completed_game) co
     cached_stats_.total_hints += segmentDelta(completed_game.hints_used, carried_hints);
     cached_stats_.total_mistakes += segmentDelta(completed_game.mistakes, carried_mistakes);
     cached_stats_.total_time_played += segmentDelta(completed_game.time_played, carried_time);
-
-    stats_cache_valid_ = true;
 }
 
 void StatisticsManager::invalidateStatsCache() {

--- a/src/core/statistics_manager.h
+++ b/src/core/statistics_manager.h
@@ -143,6 +143,16 @@ private:
 
     // Statistics calculation
     void updateAggregateStats(const GameStats& completed_game) const;
+
+    /// Rating-only slice of updateAggregateStats: min/max/average for the difficulty's rating,
+    /// keyed off games_played BEFORE the caller increments it.
+    void updateRatingStats(int diff_index, const GameStats& completed_game) const;
+
+    /// Carried-progress slice of updateAggregateStats: derives this segment's own moves/hints/
+    /// mistakes/time (subtracting whatever an earlier segment already banked) and adds them to
+    /// the running totals. See updateAggregateStats for why only the segment delta is banked.
+    void updateCarriedTotals(const GameStats& completed_game) const;
+
     void invalidateStatsCache();
     std::expected<void, StatisticsError> recalculateAggregateStats() const;
 

--- a/src/view_model/game_view_model.cpp
+++ b/src/view_model/game_view_model.cpp
@@ -310,15 +310,7 @@ bool GameViewModel::isCorruptedManualSave(const core::SavedGame& saved_game) {
     return false;
 }
 
-void GameViewModel::restoreGameState(const core::SavedGame& saved_game) {
-    if (isCorruptedManualSave(saved_game)) {
-        // startNewGame begins its own statistics session — deliberately none is started for the
-        // rejected save, so this path counts exactly one session (story 8.1 AC9a).
-        startNewGame(saved_game.difficulty);
-        return;
-    }
-
-    // Create a GameState from the saved game
+model::GameState GameViewModel::buildRestoredGameState(const core::SavedGame& saved_game) {
     model::GameState loaded_state;
 
     // Load original puzzle (only clues get is_given = true)
@@ -347,7 +339,18 @@ void GameViewModel::restoreGameState(const core::SavedGame& saved_game) {
         });
     }
 
-    gameState.set(loaded_state);
+    return loaded_state;
+}
+
+void GameViewModel::restoreGameState(const core::SavedGame& saved_game) {
+    if (isCorruptedManualSave(saved_game)) {
+        // startNewGame begins its own statistics session — deliberately none is started for the
+        // rejected save, so this path counts exactly one session (story 8.1 AC9a).
+        startNewGame(saved_game.difficulty);
+        return;
+    }
+
+    gameState.set(buildRestoredGameState(saved_game));
 
     // Re-seat the accumulated play time and mistake counter, then start the clock — all in ONE
     // update() lambda. GameState::operator== compares neither elapsed_time_ nor start_time_, so an

--- a/src/view_model/game_view_model.h
+++ b/src/view_model/game_view_model.h
@@ -406,6 +406,12 @@ private:
     /// or the recorded session carries rating 0.0.
     void startRestoredSession(const core::SavedGame& saved_game);
 
+    /// Rebuilds the board/notes/hint-revealed layers of a GameState from a save: loads the
+    /// original puzzle, overlays the user's entered values onto non-given cells, then restores
+    /// notes and hint-revealed markers. Pure construction — does not touch the view model's own
+    /// state (clock, move history, etc.), which restoreGameState re-seats afterward.
+    [[nodiscard]] static model::GameState buildRestoredGameState(const core::SavedGame& saved_game);
+
     /// Whether a save carries the signature of the "all cells marked given" corruption bug.
     /// Only ever true for MANUAL saves — see the implementation for why auto-saves are exempt.
     [[nodiscard]] static bool isCorruptedManualSave(const core::SavedGame& saved_game);


### PR DESCRIPTION
## Summary
- Nightly's `clang-tidy` job (`.github/workflows/nightly.yml`) has been failing since 2026-08-03 with `readability-function-size` errors — it runs a full-repo scan, unlike the PR-time `tidy-diff.sh` gate which only checks the diff against `main`, so this drift went uncaught pre-merge.
- `GameViewModel::restoreGameState` grew to 108 lines (threshold 100) via #105; `StatisticsManager::updateAggregateStats` grew to 110 lines via #107, which is what pushed nightly from a single failure to a double failure on 2026-08-04.
- Both are pure extractions with no behavior change: `restoreGameState`'s board/notes/hint-revealed reconstruction moves into a new static `buildRestoredGameState()`; `updateAggregateStats` splits into `updateRatingStats()` and `updateCarriedTotals()`, each keeping its original explanatory comment.

## Test plan
- [x] `clang-tidy-19` (CI-pinned version) on both changed files: no `readability-function-size` errors
- [x] Full RelWithDebInfo build
- [x] `./build/RelWithDebInfo/bin/tests/unit_tests` — all 1207 test cases / 18581 assertions pass
- [x] `./build/RelWithDebInfo/bin/tests/integration_tests` — all 25 test cases / 327 assertions pass
- [x] `./scripts/format.sh check` — clean
- [x] pre-push `tidy-diff.sh` CI-parity hook — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)