### PR TITLE
ci: trim Qt6 apt deps to what the app build needs, cache the rest

### DIFF
--- a/.github/actions/install-qt-deps/action.yml
+++ b/.github/actions/install-qt-deps/action.yml
@@ -30,3 +30,7 @@ runs:
           qt6-tools-dev \
           qt6-tools-dev-tools \
           libgl1-mesa-dev
+        # actions/cache saves the post-job step as the unprivileged runner
+        # user, but apt leaves lock/partial root-owned and unreadable —
+        # without this the save silently fails and every run is a cache miss.
+        sudo chmod -R a+rX /var/cache/apt/archives

--- a/.github/actions/install-qt-deps/action.yml
+++ b/.github/actions/install-qt-deps/action.yml
@@ -9,10 +9,16 @@ runs:
     # packages already declare their own runtime Depends on the xcb/X11
     # libs they need). find_package(Qt6 ... COMPONENTS Widgets Test
     # LinguistTools) in CMakeLists.txt is the full set of Qt modules used.
+    # Cache only the downloaded .deb files (mode 644, world-readable), not
+    # the whole archives dir: apt-get leaves lock/partial root-owned and
+    # unreadable by the unprivileged runner user that actions/cache's save
+    # step runs as, and *any* later sudo apt-get in the same job (e.g. a
+    # clang-tidy install step) re-creates them — so excluding them via glob
+    # is robust where a one-off chmod isn't.
     - name: Cache apt packages
       uses: actions/cache@v5
       with:
-        path: /var/cache/apt/archives
+        path: /var/cache/apt/archives/*.deb
         key: apt-${{ runner.os }}-${{ hashFiles('.github/actions/install-qt-deps/action.yml') }}
         restore-keys: |
           apt-${{ runner.os }}-
@@ -30,7 +36,3 @@ runs:
           qt6-tools-dev \
           qt6-tools-dev-tools \
           libgl1-mesa-dev
-        # actions/cache saves the post-job step as the unprivileged runner
-        # user, but apt leaves lock/partial root-owned and unreadable —
-        # without this the save silently fails and every run is a cache miss.
-        sudo chmod -R a+rX /var/cache/apt/archives

--- a/.github/actions/install-qt-deps/action.yml
+++ b/.github/actions/install-qt-deps/action.yml
@@ -4,66 +4,29 @@ description: Install system packages required for Qt6 builds on ubuntu-24.04
 runs:
   using: composite
   steps:
+    # Packages actually needed to build this app against Ubuntu's prebuilt
+    # qt6-base/qt6-tools (not to build Qt itself from source — apt's Qt6
+    # packages already declare their own runtime Depends on the xcb/X11
+    # libs they need). find_package(Qt6 ... COMPONENTS Widgets Test
+    # LinguistTools) in CMakeLists.txt is the full set of Qt modules used.
+    - name: Cache apt packages
+      uses: actions/cache@v5
+      with:
+        path: /var/cache/apt/archives
+        key: apt-${{ runner.os }}-${{ hashFiles('.github/actions/install-qt-deps/action.yml') }}
+        restore-keys: |
+          apt-${{ runner.os }}-
+
     - name: Install system dependencies
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y \
+        sudo apt-get install -y --no-install-recommends \
           build-essential \
           cmake \
           ninja-build \
           ccache \
           qt6-base-dev \
-          qt6-base-private-dev \
           qt6-tools-dev \
           qt6-tools-dev-tools \
-          libgl1-mesa-dev \
-          libx11-dev \
-          libxrandr-dev \
-          libxinerama-dev \
-          libxcursor-dev \
-          libxi-dev \
-          libudev-dev \
-          libegl1-mesa-dev \
-          libdbus-1-dev \
-          libpulse-dev \
-          libwayland-dev \
-          libxkbcommon-dev \
-          libx11-xcb-dev \
-          libfontenc-dev \
-          libice-dev \
-          libsm-dev \
-          libxaw7-dev \
-          libxcomposite-dev \
-          libxdamage-dev \
-          libxkbfile-dev \
-          libxmu-dev \
-          libxmuu-dev \
-          libxpm-dev \
-          libxres-dev \
-          libxss-dev \
-          libxt-dev \
-          libxtst-dev \
-          libxv-dev \
-          libxxf86vm-dev \
-          libxcb-glx0-dev \
-          libxcb-render0-dev \
-          libxcb-render-util0-dev \
-          libxcb-xkb-dev \
-          libxcb-icccm4-dev \
-          libxcb-image0-dev \
-          libxcb-keysyms1-dev \
-          libxcb-randr0-dev \
-          libxcb-shape0-dev \
-          libxcb-sync-dev \
-          libxcb-xfixes0-dev \
-          libxcb-xinerama0-dev \
-          libxcb-dri3-dev \
-          libxcb-cursor-dev \
-          libxcb-dri2-0-dev \
-          libxcb-present-dev \
-          libxcb-composite0-dev \
-          libxcb-ewmh-dev \
-          libxcb-res0-dev \
-          libxcb-util-dev \
-          libxcb-util0-dev
+          libgl1-mesa-dev

--- a/.github/actions/install-qt-deps/action.yml
+++ b/.github/actions/install-qt-deps/action.yml
@@ -9,6 +9,18 @@ runs:
     # packages already declare their own runtime Depends on the xcb/X11
     # libs they need). find_package(Qt6 ... COMPONENTS Widgets Test
     # LinguistTools) in CMakeLists.txt is the full set of Qt modules used.
+    # /var/cache/apt/archives is root:root 755 by default: writable only by
+    # root. actions/cache's restore step runs as the unprivileged runner
+    # user, so extracting a hit back into that directory fails to create
+    # files there ("Cannot open: Permission denied") even though the files
+    # themselves are readable. Open the directory (not its contents) before
+    # the restore step touches it, sticky-bit style like /tmp.
+    - name: Prepare apt cache directory
+      shell: bash
+      run: |
+        sudo mkdir -p /var/cache/apt/archives
+        sudo chmod 1777 /var/cache/apt/archives
+
     # Cache only the downloaded .deb files (mode 644, world-readable), not
     # the whole archives dir: apt-get leaves lock/partial root-owned and
     # unreadable by the unprivileged runner user that actions/cache's save

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -105,12 +105,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install system dependencies
+        uses: ./.github/actions/install-qt-deps
+
+      - name: Install AppImage-specific dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            qt6-base-dev qt6-tools-dev qt6-tools-dev-tools libgl1-mesa-dev \
-            ninja-build ccache \
-            libfuse2
+          sudo apt-get install -y --no-install-recommends libfuse2
 
       - name: Install Conan
         run: |


### PR DESCRIPTION
## Summary
- The shared `install-qt-deps` composite action installed ~70 apt packages on every job run, uncached — ~50 of them (`libxcb-*-dev`, `libx11-*-dev`, `libxaw7-dev`, etc.) match Qt's own "build Qt from source" instructions, not what's needed to build an app against Ubuntu's prebuilt `qt6-base-dev`/`qt6-tools-dev`. A grep across `src/`, `include/`, and `CMakeLists.txt` found no use of Qt private headers, raw GL/`QOpenGL`, `QDBus`, or direct xcb/X11 headers — only `Widgets`, `Test`, and `LinguistTools` components are required.
- Trimmed the action to the 8 packages actually exercised by the build/test/lint pipeline, added `--no-install-recommends`.
- Added `actions/cache` on `/var/cache/apt/archives/*.deb` (glob, not the whole dir — see below), keyed on the action file's own hash, plus a `chmod 1777` on the directory before the restore step touches it.
- `packaging.yml`'s `appimage` job now reuses the shared action instead of maintaining its own drifting copy of the same list.

**On the motivating number:** the PR that prompted this (`darkstar79/sudoku#111`) saw this step stuck for 27+ minutes, which read as a systemic problem with the package count. Checked 8 other recent `main` runs on the *old*, untrimmed list under normal conditions and the real baseline is **~23–34s (avg ~28s)** — that 27-minute run was a one-off mirror/network anomaly, not representative. So the honest before/after is:

| State | Duration |
|---|---|
| Old list (~70 pkgs), typical run | ~23–34s |
| Old list, the anomalous run that triggered this PR | ≥27m31s (outlier) |
| Trimmed list (8 pkgs), cache miss | 22s |
| Trimmed list, cache hit | 17–22s |

The real, normal-day win is **~28s → ~20s** (~30%), not the dramatic swing the triggering run suggested. Still worth doing — smaller package list, working cache as a hedge against exactly the kind of mirror slowdown that started this, less surface area — just not the order-of-magnitude story it first looked like.

The action is shared across 9 job steps in `ci.yml`/`nightly.yml`, so this applies everywhere in one place. CI-only change, invisible to end users and packagers — no CHANGELOG entry per the project's packager-visibility rule.

## Test plan
- [x] Watched this PR's own CI runs — trimmed list builds/links/tests cleanly on ubuntu-24.04 across all jobs
- [x] Confirmed cache saves and restores cleanly (no permission errors) across all 4 jobs that use `install-qt-deps` (`i18n-check`, `test-and-coverage`, `sanitizers-unit`, `clang-tidy-diff`), not just one
- [x] Compared against 8 historical `main` runs to establish a real (non-anomalous) baseline rather than the triggering run's stall
- [ ] If any dropped package turns out load-bearing, CI will fail loudly (missing CMake component or link error) — add back only that specific package

🤖 Generated with [Claude Code](https://claude.com/claude-code)
